### PR TITLE
Fix helper typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This gem just gives access to the standard Tailwind CSS framework. If you need t
 1. Run `./bin/bundle add tailwindcss-rails`
 2. Run `./bin/rails tailwindcss:install` (on a fresh Rails application)
 
-The last option adds the purger compressor to `config/environments/production.rb`. This ensures that when `assets:precompile` is called during deployment that the unused class names are not included in the tailwind output css used by the app. It also adds a `javascript_link_tag "tailwind"` to your `app/views/application.html.erb` file.
+The last option adds the purger compressor to `config/environments/production.rb`. This ensures that when `assets:precompile` is called during deployment that the unused class names are not included in the tailwind output css used by the app. It also adds a `stylesheet_link_tag "tailwind"` to your `app/views/application.html.erb` file.
 
 You can do both things yourself, if you've changed the default setup.
 


### PR DESCRIPTION
The install task [adds a `stylesheet_link_tag`](https://github.com/rails/tailwindcss-rails/blob/main/lib/install/tailwindcss.rb#L5) into `application.html.erb`