### PR TITLE
Register dependencies with Sprockets to enable cache invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This gem just gives access to the standard Tailwind CSS framework. If you need t
 
 The last option adds the purger compressor to `config/environments/production.rb`. This ensures that when `assets:precompile` is called during deployment that the unused class names are not included in the tailwind output css used by the app. It also adds a `stylesheet_link_tag "tailwind"` to your `app/views/application.html.erb` file.
 
+However, re-compiling assets does not currently work as expected because of caching in Sprockets, so you'll need to call `assets:clobber` and `assets:precompile` on each deployment for now. 
+
 You can do both things yourself, if you've changed the default setup.
 
 If you need to customize what files are searched for class names, you need to replace the compressor line with something like:

--- a/lib/tailwindcss/compressor.rb
+++ b/lib/tailwindcss/compressor.rb
@@ -14,6 +14,9 @@ class Tailwindcss::Compressor
   end
 
   def call(input)
-    { data: Tailwindcss::Purger.purge(input[:data], keeping_class_names_from_files: @options[:files_with_class_names]) }
+    {
+      data: Tailwindcss::Purger.purge(input[:data], keeping_class_names_from_files: @options[:files_with_class_names]),
+      dependencies: @options[:files_with_class_names].map { |f| "file-digest://#{f.to_path}" }.to_set
+    }
   end
 end


### PR DESCRIPTION
Fixes #7 

The asset pipeline currently doesn't recompile the output CSS at all, because the source Tailwinds CSS file remains the same even if the templates that use the classnames change. This means that calling `assets:precompile` in production does nothing after the first time, even if templates have changed and new purging needs to happen. 

This PR adds all `files_with_class_names` used as dependencies to the compiled asset, which re-complies the output CSS correctly. 