### PR TITLE
Fix indentation for require in postcss.config.js

### DIFF
--- a/lib/install/tailwindcss_with_webpacker.rb
+++ b/lib/install/tailwindcss_with_webpacker.rb
@@ -13,7 +13,7 @@ insert_into_file "#{Webpacker.config.source_entry_path}/application.js", "\nrequ
 say "Adding minimal configuration for Tailwind CSS to work properly"
 directory Pathname.new(__dir__).join("stylesheets"), Webpacker.config.source_path.join("stylesheets")
 
-insert_into_file "postcss.config.js", "require('tailwindcss'),\n\t", before: "  require('postcss-import')"
+insert_into_file "postcss.config.js", "require('tailwindcss'),\n    ", before: "require('postcss-import')"
 
 if APPLICATION_LAYOUT_PATH.exist?
   say "Add Tailwindcss include tags in application layout"


### PR DESCRIPTION
The way it was before my change added an unexpected tab character and started the "require" at the wrong indentation level.

```
  plugins: [
  require('tailwindcss'),
	  require('postcss-import'),
```

vs:

```
  plugins: [
    require('tailwindcss'),
    require('postcss-import'),
```