### PR TITLE
Correctly purge decimal spacing classes

### DIFF
--- a/lib/tailwindcss/purger.rb
+++ b/lib/tailwindcss/purger.rb
@@ -1,5 +1,5 @@
 class Tailwindcss::Purger
-  CLASS_NAME_PATTERN       = /([:A-Za-z0-9_-]+[\.]*[\\\/:A-Za-z0-9_-]*)/
+  CLASS_NAME_PATTERN       = /([:A-Za-z0-9_-]+[\.\\\/:A-Za-z0-9_-]*)/
   OPENING_SELECTOR_PATTERN = /\..*\{/
   CLOSING_SELECTOR_PATTERN = /\s*\}/
   NEWLINE = "\n"

--- a/test/fixtures/simple.html.erb
+++ b/test/fixtures/simple.html.erb
@@ -1,2 +1,2 @@
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 translate-x-1/2">
+<div class="max-w-7xl mx-auto my-1.5 px-4 sm:px-6 lg:px-8 sm:py-0.5 translate-x-1/2">
 </div>

--- a/test/purger_test.rb
+++ b/test/purger_test.rb
@@ -2,12 +2,12 @@ require "test_helper"
 
 class Tailwindcss::PurgerTest < ActiveSupport::TestCase
   test "extract class names from string" do
-    assert_equal %w[ div class max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 translate-x-1/2 ].sort,
-      Tailwindcss::Purger.extract_class_names(%(<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 translate-x-1/2">))
+    assert_equal %w[ div class max-w-7xl mx-auto my-1.5 px-4 sm:px-6 lg:px-8 sm:py-0.5 translate-x-1/2 ].sort,
+      Tailwindcss::Purger.extract_class_names(%(<div class="max-w-7xl mx-auto my-1.5 px-4 sm:px-6 lg:px-8 sm:py-0.5 translate-x-1/2">))
   end
 
   test "extract class names from files" do
-    assert_equal %w[ div class max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 translate-x-1/2 ].sort,
+    assert_equal %w[ div class max-w-7xl mx-auto my-1.5 px-4 sm:px-6 lg:px-8 sm:py-0.5 translate-x-1/2 ].sort,
       Tailwindcss::Purger.extract_class_names_from(Pathname.new(__dir__).join("fixtures/simple.html.erb"))
   end
 
@@ -20,6 +20,8 @@ class Tailwindcss::PurgerTest < ActiveSupport::TestCase
     assert purged =~ /.sm\\:px-6 \{/
     assert purged =~ /.translate-x-1\\\/2 \{/
     assert purged =~ /.mt-10 \{/
+    assert purged =~ /.my-1\\.5 \{/
+    assert purged =~ /.sm\\:py-0\\.5 \{/
   end
 
   test "purge shouldn't remove hover or focus classes" do
@@ -30,9 +32,7 @@ class Tailwindcss::PurgerTest < ActiveSupport::TestCase
   end
 
   test "purge shouldn't remove placeholder selectors" do
-    purged = Tailwindcss::Purger.purge \
-      Pathname.new(__FILE__).join("../../app/assets/stylesheets/tailwind.css").read, 
-      keeping_class_names_from_files: Pathname(__dir__).join("fixtures/placeholders.html.erb")
+    purged = purged_tailwind_from Pathname(__dir__).join("fixtures/placeholders.html.erb")
 
     assert purged =~ /.placeholder-transparent\:\:-moz-placeholder \{/
     assert purged =~ /.placeholder-transparent\:-ms-input-placeholder \{/
@@ -41,8 +41,12 @@ class Tailwindcss::PurgerTest < ActiveSupport::TestCase
 
   private
     def purged_tailwind_from_fixtures
+      purged_tailwind_from Pathname(__dir__).glob("fixtures/*.html.erb")
+    end
+
+    def purged_tailwind_from files
       Tailwindcss::Purger.purge \
         Pathname.new(__FILE__).join("../../app/assets/stylesheets/tailwind.css").read, 
-        keeping_class_names_from_files: Pathname(__dir__).glob("fixtures/*.html.erb")
+        keeping_class_names_from_files: files
     end
 end


### PR DESCRIPTION
Previously, decimal spacing classes such as `p-0.5` were incorrectly purged out. This PR fixes this by improving the class detection regex.

More details on the issue:

- The problem were utility classes that include a period, such as `px-0.5` or `gap-2.5`
- Such classes were correctly extracted from ERB, but incorrectly parsed out from the tailwind CSS file
- Because of the leading backslash required in CSS, e.g. the `.px-1\.5` class was extracted as `px-1` and it's fate was then decided by the purger as such :-)

Not sure if there was any particular reason for handling the period in the previous form of the regex, but this simple change has been working well for me so far.

Thanks for building such an awesome library, removing Webpack was a pleasure!