### PR TITLE
Faster webpack compile time

### DIFF
--- a/lib/install/stylesheets/application.scss
+++ b/lib/install/stylesheets/application.scss
@@ -1,3 +1,0 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";

--- a/lib/install/stylesheets/base.scss
+++ b/lib/install/stylesheets/base.scss
@@ -1,0 +1,4 @@
+@import "tailwindcss/base";
+
+// Add custom base styles here
+// https://tailwindcss.com/docs/adding-base-styles

--- a/lib/install/stylesheets/components.scss
+++ b/lib/install/stylesheets/components.scss
@@ -1,0 +1,4 @@
+@import "tailwindcss/components";
+
+// Import components added to `./components/` here
+// https://tailwindcss.com/docs/extracting-components

--- a/lib/install/stylesheets/utilities.scss
+++ b/lib/install/stylesheets/utilities.scss
@@ -1,0 +1,4 @@
+@import "tailwindcss/utilities";
+
+// Import vendor CSS here
+// https://tailwindcss.com/docs/adding-new-utilities

--- a/lib/install/tailwindcss_with_webpacker.rb
+++ b/lib/install/tailwindcss_with_webpacker.rb
@@ -3,7 +3,11 @@ APPLICATION_LAYOUT_PATH  = Rails.root.join("app/views/layouts/application.html.e
 
 say "Installing Tailwind CSS"
 run "yarn add tailwindcss@npm:@tailwindcss/postcss7-compat postcss@^7 autoprefixer@^9"
-insert_into_file "#{Webpacker.config.source_entry_path}/application.js", "\nimport \"stylesheets/application\"\n"
+insert_into_file "#{Webpacker.config.source_entry_path}/application.js",
+  "\n// Imported separately for faster Webpack recompilation. Order matters\""\
+  "\nimport \"stylesheets/base\""\
+  "\nimport \"stylesheets/components\""\
+  "\nimport \"stylesheets/utilities\"\n"
 
 say "Configuring Tailwind CSS"
 directory Pathname.new(__dir__).join("stylesheets"), Webpacker.config.source_path.join("stylesheets")


### PR DESCRIPTION
Hi there,

when adding custom CSS into a separate file, webpack should not have to compile the whole tailwindcss again, but only the changes in `application.scss`.

Moreover, I personally like it to have the custom CSS in a separate file and not in between the tailwind includes.

See: https://github.com/tailwindlabs/tailwindcss/issues/443#issuecomment-735583969

**Before**
<img width="419" alt="grafik" src="https://user-images.githubusercontent.com/643436/107152999-7af18d80-696b-11eb-8284-a76ae14375ad.png">

**After**
<img width="495" alt="grafik" src="https://user-images.githubusercontent.com/643436/107152943-2fd77a80-696b-11eb-999d-49607ddc5df5.png">

I hope this will help others too. 😄 


