### PR TITLE
Webpacker: Basic purging patterns

### DIFF
--- a/lib/install/stylesheets/tailwind.config.js
+++ b/lib/install/stylesheets/tailwind.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  // Purge unused TailwindCSS styles
+  purge: {
+    enabled: ["production"].includes(process.env.NODE_ENV),
+    content: [
+      './**/*.html.erb',
+      './app/helpers/**/*.rb',
+      './app/javascript/**/*.js',
+    ],
+  },
+  darkMode: false, // or 'media' or 'class'
+  theme: {
+    extend: {},
+  },
+  variants: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/lib/install/tailwindcss_with_webpacker.rb
+++ b/lib/install/tailwindcss_with_webpacker.rb
@@ -7,7 +7,6 @@ insert_into_file "#{Webpacker.config.source_entry_path}/application.js", "\nimpo
 
 say "Configuring Tailwind CSS"
 directory Pathname.new(__dir__).join("stylesheets"), Webpacker.config.source_path.join("stylesheets")
-Dir.chdir(WEBPACK_STYLESHEETS_PATH) { run "npx tailwindcss init" }
 
 insert_into_file "postcss.config.js", "require('tailwindcss')(\"./app/javascript/stylesheets/tailwind.config.js\"),\n    ",
   before: "require('postcss-import')"


### PR DESCRIPTION
This PR configures Tailwind purging with basic rails app needs.
Developers can easily change this down the road, but this should serve
as a good starting point.

-----

On bare-bones rails new (_running this in development env_):

**Before**
<img width="1044" alt="Screenshot 2021-02-08 at 14 48 41" src="https://user-images.githubusercontent.com/7427365/107228870-6ec60880-6a1d-11eb-93c4-0c1b59aaf274.png">

**After**
<img width="975" alt="Screenshot 2021-02-08 at 14 49 36" src="https://user-images.githubusercontent.com/7427365/107228854-6bcb1800-6a1d-11eb-9395-e127be124789.png">


ps
In real-world app difference will be smaller, since there is less to purge :)