### PR TITLE
Use path from webpacker config instead hardcoded path

### DIFF
--- a/lib/install/tailwindcss_with_webpacker.rb
+++ b/lib/install/tailwindcss_with_webpacker.rb
@@ -9,7 +9,7 @@ say "Configuring Tailwind CSS"
 directory Pathname.new(__dir__).join("stylesheets"), Webpacker.config.source_path.join("stylesheets")
 Dir.chdir(WEBPACK_STYLESHEETS_PATH) { run "npx tailwindcss init" }
 
-insert_into_file "postcss.config.js", "require('tailwindcss')(\"./app/javascript/stylesheets/tailwind.config.js\"),\n    ",
+insert_into_file "postcss.config.js", "require('tailwindcss')(\".#{WEBPACK_STYLESHEETS_PATH.sub(Rails.root.to_s, '')}/tailwind.config.js\"),\n    ",
   before: "require('postcss-import')"
 
 


### PR DESCRIPTION

I couldn't find a public method for getting [Webpacker config](https://github.com/rails/webpacker/blob/master/lib/webpacker/configuration.rb) relative path, so I just substitute Rails root path with empty string. 