### PR TITLE
Set up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [2.7, "3.0"]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler: latest
+          bundler-cache: true
+
+      - name: Run tests
+        run: bin/test


### PR DESCRIPTION
This excludes `head` from the Ruby version matrix due to an issue with installing Nokogiri, described by sparklemotion/nokogiri#2185.

---

Copied from [kredis](https://github.com/rails/kredis/blob/ab79f255c53bfb5e760c08644222af6fe215f253/.github/workflows/ci.yml).  Thank you, @kaspth!