### PR TITLE
Fix "Update Tailwind" action

### DIFF
--- a/.github/workflows/update-tailwind.yml
+++ b/.github/workflows/update-tailwind.yml
@@ -11,16 +11,18 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@master
-    - name: Update app/assets/stylesheets/tailwind.css
+
+    - name: Update tailwind.css
       run: |
-        npx tailwindcss-cli@latest build -o app/assets/stylesheets/tailwind.css
-    - name: Commit files
+        yarn upgrade tailwindcss
+        yarn build
+
+    - name: Commit changes
       run: |
-        TAILWIND_CSS_VERSION=`npm view tailwindcss@latest version`
         git config --local user.email "github-actions@example.com"
         git config --local user.name "GitHub Actions"
-        git add app/assets/stylesheets/tailwind.css
-        git commit -am "[nodoc] Updating Tailwind CSS to $TAILWIND_CSS_VERSION" || echo "No changes to commit"
+        git commit -am "Update tailwind.css" || echo "No changes to commit"
+
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:


### PR DESCRIPTION
`tailwindcss-cli build` chokes on `require('tailwindcss/defaultTheme')` in `tailwind.config.js` added by 53089c1e1fb2f0ae232621a057320338436efa33.  Example failure: https://github.com/rails/tailwindcss-rails/runs/1725407564.

`tailwind build`, which is invoked by `yarn build`, handles this properly.  Running `yarn upgrade tailwindcss` beforehand ensures that the `tailwind build` command is installed, and updates the Tailwind version in `yarn.lock` to match the built `tailwind.css`.

---

Example success after this change: https://github.com/jonathanhefner/tailwindcss-rails/runs/1954932857.  Resulting commit: https://github.com/jonathanhefner/tailwindcss-rails/commit/9dd13676ba95982b914c13a6d3ad7de2b4688fa1.