### PR TITLE
Support customization via CSS custom properties

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,15 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
+const cssVar = (name, defaultValue) => `var(--tw-${name}, ${defaultValue})`
+
 module.exports = {
   darkMode: 'media',
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+        sans: cssVar('font-family-sans', ['"Inter var"', ...defaultTheme.fontFamily.sans]),
+        serif: cssVar('font-family-serif', defaultTheme.fontFamily.serif),
+        mono: cssVar('font-family-mono', defaultTheme.fontFamily.mono),
       },
     },
   },


### PR DESCRIPTION
This is an alternative or supplement to #14.  From rudimentary testing, evaluating a `tailwind.css.erb` file is *extremely* slow (10+ seconds).  Sprockets will cache the output so that the cost does not need to be paid for every request, but that also raises the issue of cache invalidation.  Using CSS custom properties sidesteps these concerns.

There is a larger question of which customizations to support via CSS custom properties.  Font families are an obvious and simple choice, which is why I've started with them.

In contrast, there are a [few dozen spacing values](https://github.com/tailwindlabs/tailwindcss/blob/0b15037e675d946b8e2f0b6186e7cf94314e25bb/stubs/defaultConfig.stub.js#L30-L66), and full customization thereof would be more cumbersome.  Also, speaking as a non-designer, the value of customizing them seems questionable, since they are already expressed in `rem`, and there is a clear linear relationship between them.

The choice for color customization is less clear.  Note that the default Tailwind color palette is all handpicked, because generating shades algorithmically currently yields suboptimal results.  So whatever customization mechanism we provide would likely need to support specifying multiple shades.  Also, speaking as a non-designer, the value of overriding concrete colors (e.g. `blue-500`) seems questionable.  On the other hand, the ability to specify abstract colors (e.g. `primary-darker`) seems valuable.  Vanilla Tailwind doesn't include such abstract colors, but we could still make them a part of our offering and let the purger strip them away if they go unused.

One more area for customization is the `tailwindcss-typography` plugin.  It provides [many low-level configuration options](https://github.com/tailwindlabs/tailwindcss-typography/blob/6566aa3b84e45ea873ead29f29158cf3ca9ca7aa/src/styles.js#L13).  At some point in the future it may provide higher-level configuration options, but we could provide our own in the mean time.  For example, `--tw-prose-color` and `--tw-prose-heading-color` variables.
