### PR TITLE
Remove scaffolds styles on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ The last step adds the purger compressor to `config/environments/production.rb`.
 
 You can do these things yourself, if you've changed the default setup.
 
-Note: You should ensure to delete `app/assets/stylesheets/scaffolds.scss` that Rails adds after running a scaffold command, if you had run this generator before installing Tailwind CSS for Rails. This stylesheet will interfere with Tailwind's reset of base styles. This gem will turn off stylesheet generation for all future scaffold runs.
-
 
 ## Purging in production
 

--- a/lib/install/tailwindcss.rb
+++ b/lib/install/tailwindcss.rb
@@ -3,13 +3,13 @@ APPLICATION_LAYOUT_PATH = Rails.root.join("app/views/layouts/application.html.er
 if APPLICATION_LAYOUT_PATH.exist?
   say "Add Tailwindcss include tags in application layout"
   insert_into_file Rails.root.join("app/views/layouts/application.html.erb").to_s, %(\n    <%= stylesheet_link_tag "inter-font" %>\n    <%= stylesheet_link_tag "tailwind" %>), before: /^\s*<%= stylesheet_link_tag/
-
-  say "Removing scaffold styles"
-  remove_file Rails.root.join("app/assets/stylesheets/scaffolds.scss")
 else
   say "Default application.html.erb is missing!", :red
   say %(        Add <%= stylesheet_link_tag "inter-font" %> and <%= stylesheet_link_tag "tailwind" %> within the <head> tag in your custom layout.)
 end
+
+say "Removing scaffold styles"
+remove_file Rails.root.join("app/assets/stylesheets/scaffolds.scss")
 
 say "Turn on purging of unused css classes in production"
 gsub_file Rails.root.join("config/environments/production.rb"), /^\s+#?\s+config.assets.css_compressor =.*$/, %(  config.assets.css_compressor = :purger)

--- a/lib/install/tailwindcss.rb
+++ b/lib/install/tailwindcss.rb
@@ -3,6 +3,9 @@ APPLICATION_LAYOUT_PATH = Rails.root.join("app/views/layouts/application.html.er
 if APPLICATION_LAYOUT_PATH.exist?
   say "Add Tailwindcss include tags in application layout"
   insert_into_file Rails.root.join("app/views/layouts/application.html.erb").to_s, %(\n    <%= stylesheet_link_tag "inter-font" %>\n    <%= stylesheet_link_tag "tailwind" %>), before: /^\s*<%= stylesheet_link_tag/
+
+  say "Removing scaffold styles"
+  remove_file Rails.root.join("app/assets/stylesheets/scaffolds.scss")
 else
   say "Default application.html.erb is missing!", :red
   say %(        Add <%= stylesheet_link_tag "inter-font" %> and <%= stylesheet_link_tag "tailwind" %> within the <head> tag in your custom layout.)


### PR DESCRIPTION
This stylesheet will interfere with Tailwind's reset of base styles.