### PR TITLE
Commit auto-updates only if assets have changed

### DIFF
--- a/.github/workflows/update-tailwind.yml
+++ b/.github/workflows/update-tailwind.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         git config --local user.email "github-actions@example.com"
         git config --local user.name "GitHub Actions"
-        git commit -am "Update tailwind.css" || echo "No changes to commit"
+        git diff --quiet app/assets || git commit -am "Update tailwind.css"
 
     - name: Push changes
       uses: ad-m/github-push-action@master


### PR DESCRIPTION
Follow-up to #48.

This prevents commits that only update `yarn.lock`, such as 2338bd6187da1f588903b2ba2f1d2692a654d6a3.