### PR TITLE
Add Tailwind styled scaffold templates

### DIFF
--- a/lib/install/tailwindcss.rb
+++ b/lib/install/tailwindcss.rb
@@ -1,11 +1,13 @@
 APPLICATION_LAYOUT_PATH = Rails.root.join("app/views/layouts/application.html.erb")
 
 if APPLICATION_LAYOUT_PATH.exist?
-  say "Add Tailwindcss include tags in application layout"
+  say "Add Tailwindcss include tags and container element in application layout"
   insert_into_file APPLICATION_LAYOUT_PATH.to_s, <<~ERB.indent(4), before: /^\s*<%= stylesheet_link_tag/
     <%= stylesheet_link_tag "inter-font", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
   ERB
+  insert_into_file APPLICATION_LAYOUT_PATH.to_s, %(    <main class="container mx-auto mt-28 px-5 flex">\n  ), before: /^\s*<%= yield/
+  insert_into_file APPLICATION_LAYOUT_PATH.to_s, %(\n    </main>),  after: /^\s*<%= yield %>/
 else
   say "Default application.html.erb is missing!", :red
   say %(        Add <%= stylesheet_link_tag "inter-font", "data-turbo-track": "reload" %> and <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %> within the <head> tag in your custom layout.)

--- a/lib/tailwindcss/engine.rb
+++ b/lib/tailwindcss/engine.rb
@@ -19,5 +19,9 @@ module Tailwindcss
         env.cache = ActiveSupport::Cache.lookup_store(:null_store)
       end if Rails.env.production?
     end
+
+    config.app_generators do |g|
+      g.templates.unshift File::expand_path('../../templates', __FILE__)
+    end
   end
 end

--- a/lib/templates/erb/scaffold/_form.html.erb.tt
+++ b/lib/templates/erb/scaffold/_form.html.erb.tt
@@ -1,0 +1,43 @@
+<%%= form_with(model: <%= model_resource_name %>, class: "contents") do |form| %>
+  <%% if <%= singular_table_name %>.errors.any? %>
+    <div id="error_explanation" class="bg-red-50 text-red-500 px-3 py-2 font-medium rounded-lg mt-3">
+      <h2><%%= pluralize(<%= singular_table_name %>.errors.count, "error") %> prohibited this <%= singular_table_name %> from being saved:</h2>
+
+      <ul>
+        <%% <%= singular_table_name %>.errors.each do |error| %>
+          <li><%%= error.full_message %></li>
+        <%% end %>
+      </ul>
+    </div>
+  <%% end %>
+
+<% attributes.each do |attribute| -%>
+  <div class="field my-5">
+<% if attribute.password_digest? -%>
+    <%%= form.label :password %>
+    <%%= form.password_field :password %>
+</div>
+
+<div class="field my-5">
+    <%%= form.label :password_confirmation %>
+    <%%= form.password_field :password_confirmation, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+<% elsif attribute.attachments? -%>
+    <%%= form.label :<%= attribute.column_name %> %>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, multiple: true, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+<% else -%>
+    <%%= form.label :<%= attribute.column_name %> %>
+<% if attribute.field_type == :text_area -%>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, rows: 4, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+<% elsif attribute.field_type == :check_box -%>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, class: "block mt-2 h-5 w-5" %>
+<% else -%>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+<% end -%>
+<% end -%>
+  </div>
+
+<% end -%>
+  <div class="actions inline">
+    <%%= form.submit class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium" %>
+  </div>
+<%% end %>

--- a/lib/templates/erb/scaffold/edit.html.erb.tt
+++ b/lib/templates/erb/scaffold/edit.html.erb.tt
@@ -1,0 +1,8 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="font-bold text-4xl">Editing <%= human_name.downcase %></h1>
+
+  <%%= render "form", <%= singular_table_name %>: @<%= singular_table_name %> %>
+
+  <%%= link_to "Show this <%= human_name.downcase %>", @<%= singular_table_name %>, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  <%%= link_to "Back to <%= human_name.pluralize.downcase %>", <%= index_helper %>_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/lib/templates/erb/scaffold/index.html.erb.tt
+++ b/lib/templates/erb/scaffold/index.html.erb.tt
@@ -1,0 +1,32 @@
+<div class="w-full">
+  <%% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%%= notice %></p>
+  <%% end %>
+
+  <div class="flex justify-between items-center">
+    <h1 class="text-lg font-bold text-4xl"><%= human_name %></h1>
+    <%%= link_to 'New <%= human_name.downcase %>', new_<%= singular_route_name %>_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
+  </div>
+
+  <table class="min-w-full">
+    <thead class="border-b-2 border-gray-200">
+      <tr class="text-gray-500 uppercase text-left">
+<% attributes.reject(&:password_digest?).each do |attribute| -%>
+        <th class="pt-6 pb-2 font-normal"><%= attribute.human_name %></th>
+<% end -%>
+      </tr>
+    </thead>
+
+    <tbody>
+      <%% @<%= plural_table_name %>.each do |<%= singular_table_name %>| %>
+        <tr class="align-top border-b border-gray-200">
+<% attributes.reject(&:password_digest?).each do |attribute| -%>
+          <td class="py-6 pr-3"><%%= <%= singular_table_name %>.<%= attribute.column_name %> %></td>
+<% end -%>
+          <td class="py-6 pr-3"><%%= link_to 'Show', <%= model_resource_name %>, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %></td>
+          <td class="py-6 pr-3"><%%= link_to 'Edit', edit_<%= singular_route_name %>_path(<%= singular_table_name %>), class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %></td>
+        </tr>
+      <%% end %>
+    </tbody>
+  </table>
+</div>

--- a/lib/templates/erb/scaffold/new.html.erb.tt
+++ b/lib/templates/erb/scaffold/new.html.erb.tt
@@ -1,0 +1,7 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <h1 class="text-lg font-bold text-4xl">New <%= human_name.downcase %></h1>
+
+  <%%= render "form", <%= singular_table_name %>: @<%= singular_table_name %> %>
+
+  <%%= link_to 'Back to <%= human_name.pluralize.downcase %>', <%= index_helper %>_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+</div>

--- a/lib/templates/erb/scaffold/show.html.erb.tt
+++ b/lib/templates/erb/scaffold/show.html.erb.tt
@@ -1,0 +1,20 @@
+<div class="mx-auto md:w-2/3 w-full flex">
+  <div class="mx-auto">
+    <%% if notice.present? %>
+      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%%= notice %></p>
+    <%% end %>
+
+<% attributes.reject(&:password_digest?).each do |attribute| -%>
+    <p class="my-5">
+      <strong class="block font-medium mb-1"><%= attribute.human_name %>:</strong>
+      <%%= @<%= singular_table_name %>.<%= attribute.column_name %> %>
+    </p>
+<% end -%>
+
+    <%%= link_to 'Edit', edit_<%= singular_table_name %>_path(@<%= singular_table_name %>), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <div class="inline-block ml-2">
+      <%%= button_to 'Delete', <%= singular_table_name %>_path(@<%= singular_table_name %>), method: :delete, class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+    </div>
+    <%%= link_to 'Back', <%= index_helper %>_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

This PR adds Tailwind styled scaffold templates when this gem is installed. These styles were sanctioned by Adam and the Tailwind team. Some examples:

<img width="1440" alt="Screenshot 2021-09-03 at 09 44 50" src="https://user-images.githubusercontent.com/31761693/131969526-f6660a9d-6fe7-45cd-8afd-5f15659f37bb.png">
<img width="1359" alt="Screenshot 2021-09-03 at 09 44 03" src="https://user-images.githubusercontent.com/31761693/131969535-b7033d85-c88a-4773-b0a7-a80b7cf604f4.png">
<img width="1359" alt="Screenshot 2021-09-03 at 09 43 49" src="https://user-images.githubusercontent.com/31761693/131969538-b3f3962f-6084-4e87-946c-9b4cb4ffa397.png">


## Additional information

It would great if we had the option of using Tailwinds `@apply` directive. This would be useful when extracting components like buttons, inputs etc. But since the css comes precompiled we did what we could. 

Maybe something to work on in the future?


Co-authored-by: Dino Marić <dino.onex@gmail.com>