### PR TITLE
Update TW version in Readme after recent update

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The Tailwind CSS main file that's being used before purging consists of these ve
 * @tailwindcss/forms 0.3.3
 * @tailwindcss/typography 0.4.1
 * autoprefixer 10.3.1
-* tailwindcss 2.2.7
+* tailwindcss 2.2.15
 
 
 ## License


### PR DESCRIPTION
The Tailwind version is updated in b16e0c28e216c9131785d48c6bce6643f01f5633 by a Github Action.
This commit updates the Readme accordingly. 