### PR TITLE
FIX: Error when generating a controller.

### DIFF
--- a/lib/generators/tailwindcss/controller/controller_generator.rb
+++ b/lib/generators/tailwindcss/controller/controller_generator.rb
@@ -1,0 +1,9 @@
+require "rails/generators/erb/controller/controller_generator"
+
+module Tailwindcss
+  module Generators
+    class ControllerGenerator < Erb::Generators::ControllerGenerator
+      source_root File.expand_path("../templates", __FILE__)
+    end
+  end
+end

--- a/lib/generators/tailwindcss/controller/templates/view.html.erb.tt
+++ b/lib/generators/tailwindcss/controller/templates/view.html.erb.tt
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="text-xl font-bold"><%= class_name %>#<%= @action %></h1>
+  <p>Find me in <%= @path %></p>
+<div>

--- a/test/lib/generators/tailwindcss/controller_generator_test.rb
+++ b/test/lib/generators/tailwindcss/controller_generator_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+require "generators/tailwindcss/controller/controller_generator"
+
+class Tailwindcss::Generators::ControllerGeneratorTest < Rails::Generators::TestCase
+  GENERATION_PATH = File.expand_path("../controller_tmp", File.dirname(__FILE__))
+
+  tests Tailwindcss::Generators::ControllerGenerator
+  destination GENERATION_PATH
+
+  arguments %w(Messages index show)
+
+   Minitest.after_run do
+     FileUtils.rm_rf GENERATION_PATH
+   end
+
+  test "generates correct view templates" do
+    run_generator
+    assert_file "app/views/messages/index.html.erb"
+    assert_file "app/views/messages/show.html.erb"
+  end
+end
+

--- a/test/lib/generators/tailwindcss/scaffold_generator_test.rb
+++ b/test/lib/generators/tailwindcss/scaffold_generator_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require "generators/tailwindcss/scaffold/scaffold_generator"
 
 class Tailwindcss::Generators::ScaffoldGeneratorTest < Rails::Generators::TestCase
-  GENERATION_PATH = File.expand_path("../tmp", File.dirname(__FILE__))
+  GENERATION_PATH = File.expand_path("../scaffold_tmp", File.dirname(__FILE__))
 
   tests Tailwindcss::Generators::ScaffoldGenerator
   destination GENERATION_PATH


### PR DESCRIPTION
This PR fixes error on the controller generation:

`bin/rails g controller Home index`

Since, I'd to override rails scaffold controller to work with rails 6, I
needed to configure rails controller generator also.