### PR TITLE
Add support for Rails 5.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     tailwindcss-rails (0.5.1)
-      rails (>= 6.0.0)
+      rails (>= 5.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/generators/tailwindcss/scaffold/templates/_form.html.erb.tt
+++ b/lib/generators/tailwindcss/scaffold/templates/_form.html.erb.tt
@@ -21,7 +21,7 @@
 <div class="my-5">
     <%%= form.label :password_confirmation %>
     <%%= form.password_field :password_confirmation, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
-<% elsif attribute.attachments? -%>
+<% elsif attribute.try(:attachments?) -%>
     <%%= form.label :<%= attribute.column_name %> %>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, multiple: true, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
 <% else -%>

--- a/lib/generators/tailwindcss/scaffold/templates/partial.html.erb.tt
+++ b/lib/generators/tailwindcss/scaffold/templates/partial.html.erb.tt
@@ -2,9 +2,9 @@
 <% attributes.reject(&:password_digest?).each do |attribute| -%>
   <p class="my-5">
     <strong class="block font-medium mb-1"><%= attribute.human_name %>:</strong>
-<% if attribute.attachment? -%>
+<% if attribute.try(:attachment?) -%>
     <%%= link_to <%= singular_table_name %>.<%= attribute.column_name %>.filename, <%= singular_table_name %>.<%= attribute.column_name %> if <%= singular_table_name %>.<%= attribute.column_name %>.attached? %>
-<% elsif attribute.attachments? -%>
+<% elsif attribute.try(:attachments?) -%>
     <%% <%= singular_table_name %>.<%= attribute.column_name %>.each do |<%= attribute.singular_name %>| %>
       <div><%%= link_to <%= attribute.singular_name %>.filename, <%= attribute.singular_name %> %></div>
     <%% end %>

--- a/tailwindcss-rails.gemspec
+++ b/tailwindcss-rails.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", ">= 6.0.0"
+  spec.add_dependency "rails", ">= 5.0.0"
 end


### PR DESCRIPTION
Giving this another go, since we need this in order to add tailwindcss generator for the `view_component`.

View component is `rails >= 5`