### PR TITLE
Add actionmailer test dependency to fix test suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ gemspec
 
 gem "sqlite3"
 gem "debug", ">= 1.0.0"
+
+group :test do
+  gem "actionmailer", ">= 6.0.0"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    actionmailer (6.1.4.1)
+      actionpack (= 6.1.4.1)
+      actionview (= 6.1.4.1)
+      activejob (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
     actionpack (6.1.4.1)
       actionview (= 6.1.4.1)
       activesupport (= 6.1.4.1)
@@ -20,6 +27,9 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (6.1.4.1)
+      activesupport (= 6.1.4.1)
+      globalid (>= 0.3.6)
     activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -33,6 +43,8 @@ GEM
       irb
       reline (>= 0.2.7)
     erubi (1.10.0)
+    globalid (1.0.0)
+      activesupport (>= 5.0)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     io-console (0.5.9)
@@ -41,7 +53,10 @@ GEM
     loofah (2.12.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    mail (2.7.1)
+      mini_mime (>= 0.1.1)
     method_source (1.0.0)
+    mini_mime (1.1.2)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
     nokogiri (1.12.5)
@@ -75,6 +90,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionmailer (>= 6.0.0)
   debug (>= 1.0.0)
   sqlite3
   tailwindcss-rails!


### PR DESCRIPTION
The test suite was failing with:
```
/home/runner/work/tailwindcss-rails/tailwindcss-rails/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:332:in `require': cannot load such file -- rails/generators/mailer/mailer_generator (LoadError)
	from /home/runner/work/tailwindcss-rails/tailwindcss-rails/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:332:in `block in require'
	from /home/runner/work/tailwindcss-rails/tailwindcss-rails/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /home/runner/work/tailwindcss-rails/tailwindcss-rails/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:332:in `require'
	from /home/runner/work/tailwindcss-rails/tailwindcss-rails/test/lib/generators/tailwindcss/mailer_generator_test.rb:2:in `<top (required)>'
	from /home/runner/work/tailwindcss-rails/tailwindcss-rails/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:332:in `require'
	from /home/runner/work/tailwindcss-rails/tailwindcss-rails/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:332:in `block in require'
	from /home/runner/work/tailwindcss-rails/tailwindcss-rails/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:299:in `load_dependency'
	from /home/runner/work/tailwindcss-rails/tailwindcss-rails/vendor/bundle/ruby/2.7.0/gems/activesupport-6.1.4.1/lib/active_support/dependencies.rb:332:in `require'
	from /home/runner/work/tailwindcss-rails/tailwindcss-rails/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.1/lib/rails/test_unit/runner.rb:50:in `block in load_tests'
	from /home/runner/work/tailwindcss-rails/tailwindcss-rails/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.1/lib/rails/test_unit/runner.rb:50:in `each'
	from /home/runner/work/tailwindcss-rails/tailwindcss-rails/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.1/lib/rails/test_unit/runner.rb:50:in `load_tests'
	from /home/runner/work/tailwindcss-rails/tailwindcss-rails/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.1/lib/rails/test_unit/runner.rb:39:in `run'
	from /home/runner/work/tailwindcss-rails/tailwindcss-rails/vendor/bundle/ruby/2.7.0/gems/railties-6.1.4.1/lib/rails/plugin/test.rb:9:in `<top (required)>'
	from bin/test:5:in `require'
	from bin/test:5:in `<main>'
Error: Process completed with exit code 1.
```
https://github.com/rails/tailwindcss-rails/runs/4413788255?check_suite_focus=true#step:4:4

This was caused by 1233c7aca352f757c23753585ea980b71e7991f3 which replaced the dependency on `rails` with a dependency on `railties`. As a result, `actionmailer` was no longer being installed, but this line depends on `actionmailer`:
https://github.com/rails/tailwindcss-rails/blob/b33f034702a2dd9d8eed2a737b11a4342dde0faf/test/lib/generators/tailwindcss/mailer_generator_test.rb#L2
since `rails/generators/mailer/mailer_generator` is [provided by `actionmailer`](https://github.com/rails/rails/blob/90357af08048ef5076730505f6e7b14a81f33d0c/actionmailer/lib/rails/generators/mailer/mailer_generator.rb).

Thus, we need `actionmailer` to be installed in order to run that test.