### PR TITLE
Remove redundant font-size class from generators

### DIFF
--- a/lib/generators/tailwindcss/controller/templates/view.html.erb.tt
+++ b/lib/generators/tailwindcss/controller/templates/view.html.erb.tt
@@ -1,4 +1,4 @@
 <div>
-  <h1 class="text-lg font-bold text-4xl"><%= class_name %>#<%= @action %></h1>
+  <h1 class="font-bold text-4xl"><%= class_name %>#<%= @action %></h1>
   <p>Find me in <%= @path %></p>
 </div>

--- a/lib/generators/tailwindcss/scaffold/templates/index.html.erb.tt
+++ b/lib/generators/tailwindcss/scaffold/templates/index.html.erb.tt
@@ -4,7 +4,7 @@
   <%% end %>
 
   <div class="flex justify-between items-center">
-    <h1 class="text-lg font-bold text-4xl"><%= human_name.pluralize %></h1>
+    <h1 class="font-bold text-4xl"><%= human_name.pluralize %></h1>
     <%%= link_to 'New <%= human_name.downcase %>', new_<%= singular_route_name %>_path, class: "rounded-lg py-3 px-5 bg-blue-600 text-white block font-medium" %>
   </div>
 

--- a/lib/generators/tailwindcss/scaffold/templates/new.html.erb.tt
+++ b/lib/generators/tailwindcss/scaffold/templates/new.html.erb.tt
@@ -1,5 +1,5 @@
 <div class="mx-auto md:w-2/3 w-full">
-  <h1 class="text-lg font-bold text-4xl">New <%= human_name.downcase %></h1>
+  <h1 class="font-bold text-4xl">New <%= human_name.downcase %></h1>
 
   <%%= render "form", <%= singular_table_name %>: @<%= singular_table_name %> %>
 


### PR DESCRIPTION
Signed-off-by: Marcus Heng <marcushwz@gmail.com>

There are redundant class names for font-size in some of the default generators. This is what get generated when I do:

```bash
rails g controller static_pages home
```

<img width="650" alt="image" src="https://user-images.githubusercontent.com/40255418/146628303-f6db6c55-e97a-4ae2-ac60-96a3dd3ed312.png">

In this PR, I have removed the `text-lg` from the affected generators. The comparison of `text-lg` and `text-4xl` are as follow:

- `text-4xl`
<img width="446" alt="image" src="https://user-images.githubusercontent.com/40255418/146628359-f2625a5d-3d81-4d84-99c9-a75727333d2b.png">

- `text-lg`
<img width="422" alt="image" src="https://user-images.githubusercontent.com/40255418/146628380-75617721-f454-452e-9745-fb8d1332a0e1.png">


