### PR TITLE
Remove setting the `dark-mode` explicitly

### DIFF
--- a/lib/install/tailwind.config.js
+++ b/lib/install/tailwind.config.js
@@ -1,12 +1,11 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
-  darkMode: 'media',
   content: [
     './app/helpers/**/*.rb',
     './app/javascript/**/*.js',
     './app/views/**/*'
-  ],  
+  ],
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
The dark mode feature  is now enabled by default.

<img width="791" alt="Screenshot 2021-12-19 at 11 50 07" src="https://user-images.githubusercontent.com/7427365/146672352-ca09287f-c09d-4de3-9128-8f2e9887452b.png">

[Source](https://tailwindcss.com/docs/upgrade-guide#remove-dark-mode-configuration)