### PR TITLE
error messages on unsupported platforms or when bundler platforms aren't correct

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["x64-mingw32", "x86_64-darwin", "x86_64-linux"]
+        platform: ["ruby", "x64-mingw32", "x86_64-darwin", "x86_64-linux"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -20,6 +20,20 @@ jobs:
           name: gem-${{matrix.platform}}
           path: pkg
           retention-days: 1
+
+  vanilla-install:
+    needs: ["package"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+      - uses: actions/download-artifact@v2
+        with:
+          name: gem-ruby
+          path: pkg
+      - run: "gem install pkg/tailwindcss-rails-*.gem"
+      - run: "tailwindcss 2>&1 | fgrep 'ERROR: Cannot find the tailwindcss executable'"
 
   linux-install:
     needs: ["package"]

--- a/exe/tailwindcss
+++ b/exe/tailwindcss
@@ -2,17 +2,37 @@
 # because rubygems shims assume a gem's executables are Ruby
 
 require "shellwords"
+require "tailwindcss/upstream"
 
-platform_dir = Dir.glob(File.join(__dir__, "*")).select do |f|
-  File.directory?(f) && Gem::Platform.match(File.basename(f))
-end.first
-if platform_dir.nil?
-  raise "Cannot find the tailwindcss executable in #{__dir__} (1)"
+supported_platforms = Tailwindcss::Upstream::NATIVE_PLATFORMS.keys
+
+if supported_platforms.none? { |supported_platform| Gem::Platform.match(supported_platform) }
+  STDERR.puts(<<~ERRMSG)
+    ERROR: tailwindcss-rails does not support the #{::Gem::Platform.local} platform
+    Please install tailwindcss following instructions at https://tailwindcss.com/docs/installation
+  ERRMSG
+  exit 1
 end
 
-exe_path = File.join(platform_dir, "tailwindcss")
-if !File.exist?(exe_path)
-  raise "Cannot find the tailwindcss executable in #{__dir__} (2)"
+exe_path = Dir.glob(File.join(__dir__, "*", "tailwindcss")).find do |f|
+  Gem::Platform.match(File.basename(File.dirname(f)))
+end
+if exe_path.nil?
+  STDERR.puts(<<~ERRMSG)
+    ERROR: Cannot find the tailwindcss executable for #{::Gem::Platform.local} in #{__dir__}
+    If you're using bundler, please make sure you're on the latest bundler version:
+
+      gem install bundler
+      bundle update --bundler
+
+    Then make sure your lock file includes this platform by running:
+
+      bundle lock --add-platform #{::Gem::Platform.local}
+      bundle install
+
+    See `bundle lock --help` output for details.
+  ERRMSG
+  exit 1
 end
 
 command = Shellwords.join([exe_path, ARGV].flatten)

--- a/lib/tailwindcss-rails.rb
+++ b/lib/tailwindcss-rails.rb
@@ -1,5 +1,6 @@
 module Tailwindcss
 end
 
+require "tailwindcss/upstream"
 require "tailwindcss/version"
 require "tailwindcss/engine"

--- a/lib/tailwindcss/upstream.rb
+++ b/lib/tailwindcss/upstream.rb
@@ -1,0 +1,14 @@
+module Tailwindcss
+  # constants describing the upstream tailwindcss project
+  module Upstream
+    VERSION = "v3.0.5"
+
+    # rubygems platform name => upstream release filename
+    NATIVE_PLATFORMS = {
+      "arm64-darwin" => "tailwindcss-macos-arm64",
+      "x64-mingw32" => "tailwindcss-windows-x64.exe",
+      "x86_64-darwin" => "tailwindcss-macos-x64",
+      "x86_64-linux" => "tailwindcss-linux-x64",
+    }
+  end
+end

--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -77,7 +77,6 @@ Tailwindcss::Upstream::NATIVE_PLATFORMS.each do |platform, filename|
 
     # modify a copy of the gemspec to include the native executable
     gemspec.platform = platform
-    gemspec.executables << "tailwindcss"
     gemspec.files += [exepath, "LICENSE-DEPENDENCIES"]
 
     # create a package task

--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -4,8 +4,8 @@
 #
 #  TL;DR: run "rake package"
 #
-#  The native platform gems (defined by TAILWINDCSS_NATIVE_PLATFORMS below) will each contain two
-#  files in addition to what the vanilla ruby gem contains:
+#  The native platform gems (defined by Tailwindcss::Upstream::NATIVE_PLATFORMS) will each contain
+#  two files in addition to what the vanilla ruby gem contains:
 #
 #     exe/
 #     ├── tailwindcss                             #  generic ruby script to find and run the binary
@@ -56,19 +56,10 @@
 #
 require "rubygems/package_task"
 require "open-uri"
-
-TAILWINDCSS_VERSION = "v3.0.5" # string used to generate the download URL
-
-# rubygems platform name => upstream release filename
-TAILWINDCSS_NATIVE_PLATFORMS = {
-  "arm64-darwin" => "tailwindcss-macos-arm64",
-  "x64-mingw32" => "tailwindcss-windows-x64.exe",
-  "x86_64-darwin" => "tailwindcss-macos-x64",
-  "x86_64-linux" => "tailwindcss-linux-x64",
-}
+require_relative "../lib/tailwindcss/upstream"
 
 def tailwindcss_download_url(filename)
-  "https://github.com/tailwindlabs/tailwindcss/releases/download/#{TAILWINDCSS_VERSION}/#{filename}"
+  "https://github.com/tailwindlabs/tailwindcss/releases/download/#{Tailwindcss::Upstream::VERSION}/#{filename}"
 end
 
 TAILWINDCSS_RAILS_GEMSPEC = Bundler.load_gemspec("tailwindcss-rails.gemspec")
@@ -78,7 +69,7 @@ desc "Build the ruby gem"
 task "gem:ruby" => [gem_path]
 
 exepaths = []
-TAILWINDCSS_NATIVE_PLATFORMS.each do |platform, filename|
+Tailwindcss::Upstream::NATIVE_PLATFORMS.each do |platform, filename|
   TAILWINDCSS_RAILS_GEMSPEC.dup.tap do |gemspec|
     exedir = File.join(gemspec.bindir, platform) # "exe/x86_64-linux"
     exepath = File.join(exedir, "tailwindcss") # "exe/x86_64-linux/tailwindcss"

--- a/tailwindcss-rails.gemspec
+++ b/tailwindcss-rails.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   spec.bindir = "exe"
+  spec.executables << "tailwindcss"
 
   spec.add_dependency "railties", ">= 6.0.0"
 end


### PR DESCRIPTION
### what problem is being solved

See #101 and comments in #96 to see some problems users are having where either:

- the `ruby` platform (vanilla) gem is installed and so `tailwindcss` is simply not found in the user's path
- bundler's lockfile needs to be updated with the current platform

### what changes are being made

This PR introduces two changes:

- upstream tailwindcss metadata are moved from the rakefile into lib/tailwindcss/upstream.rb for use by the gem
- the `exe/tailwindcss` script is always shipped with the gem

An job is added to the gem-install actions pipeline to test the scenario where a bundler lockfile needs to have the native platform added.

### what will users see

The net result is that when someone has the "ruby" platform vanilla gem installed because their platform is not supported, they will see this error message when they run "tailwindcss":

``` text
ERROR: tailwindcss-rails does not support the <platformname> platform
Please install tailwindcss following instructions at https://tailwindcss.com/docs/installation
```


When someone has the "ruby" platform vanilla gem installed because their bundler lockfile does not contain the current system's platform, they will see this error message when they run "tailwindcss":

``` text
ERROR: Cannot find the tailwindcss executable for x86_64-linux in /home/flavorjones/.rbenv/versions/3.0.3/lib/ruby/gems/3.0.0/gems/tailwindcss-rails-2.0.0/exe
If you're using bundler, please make sure you're on the latest bundler version:

  gem install bundler
  bundle update --bundler

Then make sure your lock file includes this platform by running:

  bundle lock --add-platform x86_64-linux
  bundle install

See `bundle lock --help` output for details.
```
