### PR TITLE
Fix: Insert centring container around the yield

### DIFF
--- a/lib/install/tailwindcss.rb
+++ b/lib/install/tailwindcss.rb
@@ -1,12 +1,14 @@
-APPLICATION_LAYOUT_PATH = Rails.root.join("app/views/layouts/application.html.erb")
+APPLICATION_LAYOUT_PATH             = Rails.root.join("app/views/layouts/application.html.erb")
+CENTERING_CONTAINER_INSERTION_POINT = /^\s*<%= yield %>/.freeze
 
 if APPLICATION_LAYOUT_PATH.exist?
   say "Add Tailwindcss include tags and container element in application layout"
   insert_into_file APPLICATION_LAYOUT_PATH.to_s, <<~ERB.indent(4), before: /^\s*<%= stylesheet_link_tag/
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
   ERB
-  insert_into_file APPLICATION_LAYOUT_PATH.to_s, %(    <main class="container mx-auto mt-28 px-5 flex">\n  ), before: /^\s*<%= yield/
-  insert_into_file APPLICATION_LAYOUT_PATH.to_s, %(\n    </main>),  after: /^\s*<%= yield %>/
+
+  insert_into_file APPLICATION_LAYOUT_PATH.to_s, %(    <main class="container mx-auto mt-28 px-5 flex">\n  ), before: CENTERING_CONTAINER_INSERTION_POINT
+  insert_into_file APPLICATION_LAYOUT_PATH.to_s, %(\n    </main>),  after: CENTERING_CONTAINER_INSERTION_POINT
 else
   say "Default application.html.erb is missing!", :red
   say %(        Add <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %> within the <head> tag in your custom layout.)


### PR DESCRIPTION
Insertion point of the centering container was problematic.
Meaning, if someone has a `yield :somethig`
inside theirs `application.html.erb` old regex would pick that as a
insertion point and possiblly break the html structure.

This commit makes that regex more rigid to only insert centering
container around the `<%= yield %>`.

Fixes: https://github.com/rails/tailwindcss-rails/issues/98