### PR TITLE
Add tailwindcss-linux-arm64 support (make docker on Apple Silicon M1 workflow possible)

### DIFF
--- a/lib/tailwindcss/upstream.rb
+++ b/lib/tailwindcss/upstream.rb
@@ -9,6 +9,7 @@ module Tailwindcss
       "x64-mingw32" => "tailwindcss-windows-x64.exe",
       "x86_64-darwin" => "tailwindcss-macos-x64",
       "x86_64-linux" => "tailwindcss-linux-x64",
+      "aarch64-linux" => "tailwindcss-linux-arm64",
     }
   end
 end

--- a/lib/tailwindcss/upstream.rb
+++ b/lib/tailwindcss/upstream.rb
@@ -1,7 +1,7 @@
 module Tailwindcss
   # constants describing the upstream tailwindcss project
   module Upstream
-    VERSION = "v3.0.7"
+    VERSION = "v3.0.8"
 
     # rubygems platform name => upstream release filename
     NATIVE_PLATFORMS = {

--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -27,6 +27,7 @@
 #  So the full set of gem files created will be:
 #
 #  - pkg/tailwindcss-rails-1.0.0.gem
+#  - pkg/tailwindcss-rails-1.0.0-aarch64-linux.gem
 #  - pkg/tailwindcss-rails-1.0.0-arm64-darwin.gem
 #  - pkg/tailwindcss-rails-1.0.0-x64-mingw32.gem
 #  - pkg/tailwindcss-rails-1.0.0-x86_64-darwin.gem
@@ -39,6 +40,7 @@
 #  New rake tasks created:
 #
 #  - rake gem:ruby           # Build the ruby gem
+#  - rake gem:aarch64-linux  # Build the aarch64-linux gem
 #  - rake gem:arm64-darwin   # Build the arm64-darwin gem
 #  - rake gem:x64-mingw32    # Build the x64-mingw32 gem
 #  - rake gem:x86_64-darwin  # Build the x86_64-darwin gem


### PR DESCRIPTION
In this pull request: https://github.com/tailwindlabs/tailwindcss/pull/6693 I am adding linux-arm64 support to the tailwind standalone-cli.

This pull request adds linux-arm64 as a supported platform. It should only be merged after the pull request above has been merged.