### PR TITLE
Support for arm64-darwin-21

### DIFF
--- a/lib/tailwindcss/upstream.rb
+++ b/lib/tailwindcss/upstream.rb
@@ -6,6 +6,7 @@ module Tailwindcss
     # rubygems platform name => upstream release filename
     NATIVE_PLATFORMS = {
       "arm64-darwin" => "tailwindcss-macos-arm64",
+      "arm64-darwin-21" => "tailwindcss-macos-arm64",
       "x64-mingw32" => "tailwindcss-windows-x64.exe",
       "x86_64-darwin" => "tailwindcss-macos-x64",
       "x86_64-linux" => "tailwindcss-linux-x64",


### PR DESCRIPTION
## Steps to reproduce
1. Make sure to run these commands on a M1 Pro machine
2. Run `./bin/bundle add tailwindcss-rails`
3. Run `./bin/rails tailwindcss:install` 

## Expected
Tailwind is correctly installed in the app

## Actual
The following error is displayed:
```
ERROR: Cannot find the tailwindcss executable for arm64-darwin-21 in ~/.gem/ruby/3.0.3/gems/tailwindcss-rails-2.0.2/exe
If you're using bundler, please make sure you're on the latest bundler version:

  gem install bundler
  bundle update --bundler

Then make sure your lock file includes this platform by running:

  bundle lock --add-platform arm64-darwin-21
  bundle install

See `bundle lock --help` output for details.
```

## Description
Apple's M1 Pro chip is referenced as arm64-darwin-21. So the
installation process can't succeed because the executable file is
missing for the platform.

In order to test this, I did the following:
1. Cloned the repo,
2. Updated the NATIVE_PLATOFORMS constant
3. Ran `rake gem:arm64-darwin-21`
4. Copied the newly generated folder from the gem's repo `./exe/arm64-darwin-21` to the gem's folder in my machine `~/.gem/ruby/3.0.3/gems/tailwindcss-rails-2.0.2/exe/arm64-darwin-21`
5. Ran the `./bin/rails tailwindcss:install` command and everything worked successfully
6. Tailwind was properly installed

Perhaps we could update the package.rake to alias arm64-darwin to arm64-darwin-21 or something similar. Perhaps this will make more sense if it becomes a trend for Apple to change their processor's arch name after a new release. I'm still unsure if the M1 Max has a different name, I'd bet it does.