### PR TITLE
Add additional recovery step when running into platform related issues.

### DIFF
--- a/exe/tailwindcss
+++ b/exe/tailwindcss
@@ -34,7 +34,9 @@ if exe_path.nil?
     See `bundle lock --help` output for details.
         
     If you're still seeing this message after taking those steps, try running
-    `bundle config` and ensure `force_ruby_platform` isn't set to `true`.
+    `bundle config` and ensure `force_ruby_platform` isn't set to `true`. See
+    https://github.com/rails/tailwindcss-rails#check-bundle_force_ruby_platform
+    for more details.
   ERRMSG
   exit 1
 end

--- a/exe/tailwindcss
+++ b/exe/tailwindcss
@@ -32,6 +32,9 @@ if exe_path.nil?
       bundle install
 
     See `bundle lock --help` output for details.
+        
+    If you're still seeing this message after taking those steps, check that you 
+    don't have `BUNDLE_FORCE_RUBY_PLATFORM` set to `true` in `~/.bundle/config`.
   ERRMSG
   exit 1
 end

--- a/exe/tailwindcss
+++ b/exe/tailwindcss
@@ -33,8 +33,8 @@ if exe_path.nil?
 
     See `bundle lock --help` output for details.
         
-    If you're still seeing this message after taking those steps, check that you 
-    don't have `BUNDLE_FORCE_RUBY_PLATFORM` set to `true` in `~/.bundle/config`.
+    If you're still seeing this message after taking those steps, try running
+    `bundle config` and ensure `force_ruby_platform` isn't set to `true`.
   ERRMSG
   exit 1
 end


### PR DESCRIPTION
Not sure the ideal wording here, but after going on the journey recorded for all posterity in https://github.com/rails/tailwindcss-rails/issues/121, I thought maybe it would make sense to add some instructions to avoid someone else suffering the same fate in the future.