### PR TITLE
add description to watch task

### DIFF
--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -6,6 +6,7 @@ namespace :tailwindcss do
     system TAILWIND_COMPILE_COMMAND
   end
 
+  desc "Watch and build your Tailwind CSS on file changes"
   task :watch do
     system "#{TAILWIND_COMPILE_COMMAND} -w"
   end


### PR DESCRIPTION
This PR adds a description to the watch rake tasks, to make it discoverable

## Why should this be added?

When starting with a fresh Rails 7 app with the tailwind option, one can get easily get confused why updates to your html do not use an rebuilt tailwind.css file  (I sure was). While using `bin/dev` might be the new canonical, preferred way, it still would be helpful to make the watch task more discoverable. I was looking for it, with `rails -T` but the task `rails tailwindcss:watch` is hidden because it has no description.