### PR TITLE
 Remove setting of tailwindcss as the default template_engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ With Rails 7 you can generate a new application preconfigured with Tailwind by u
 1. Run `./bin/bundle add tailwindcss-rails`
 2. Run `./bin/rails tailwindcss:install`
 
+## Using the included TailwindCSS generator templates
+
+Included are several pre-styled templates. 
+
+```
+Tailwindcss:
+  tailwindcss:controller
+  tailwindcss:mailer
+  tailwindcss:scaffold
+ ```
+
+Simply prepend `tailwindcss:` to the generator type for some styling.
+
+```
+rails generate tailwindcss:scaffold Post title:string content:text 
+```
+These templated styles have been set up with a container element in mind. This element is added to `views/layouts/application.html.erb` during the above install process.
+```
+<main class="container mx-auto mt-28 px-5 flex">
+  <%= yield %>
+</main>
+```
 
 ## Building in production
 

--- a/lib/tailwindcss/engine.rb
+++ b/lib/tailwindcss/engine.rb
@@ -9,9 +9,5 @@ module Tailwindcss
     initializer "tailwindcss.disable_generator_stylesheets" do
       Rails.application.config.generators.stylesheets = false
     end
-
-     config.app_generators do |g|
-       g.template_engine :tailwindcss
-     end
   end
 end


### PR DESCRIPTION
Not sure why we set `g.template_engine :tailwindcss` it is not a typical template engine like `erb, haml, slim` and others.

One adverse effect of setting it to `tailwindcss` is RSpec view generators will  not use the correct template name.
Eg: `spec/views/home/index.html.tailwindcss_spec.rb`  where it should be `spec/views/home/index.html.erb.rb`

Removing the config resolves the above issue.