### PR TITLE
Add a tailwindcss:minify task

### DIFF
--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -10,6 +10,11 @@ namespace :tailwindcss do
   task :watch do
     system "#{TAILWIND_COMPILE_COMMAND} -w"
   end
+  
+  desc "Minify your Tailwind CSS file"
+  task :minify do
+    system "#{TAILWIND_COMPILE_COMMAND} --minify"
+  end
 end
 
 Rake::Task["assets:precompile"].enhance(["tailwindcss:build"])


### PR DESCRIPTION
Thanks to official Tailwind CSS documentation, with "Tailwind CLI, you can minify your CSS by adding the --minify flag" (source: https://tailwindcss.com/docs/optimizing-for-production).

Can we have first a minify task like this proposition on the tailwindcss-rails gem?

#greenit