### PR TITLE
Installer: don't add main in existing projects

### DIFF
--- a/lib/install/tailwindcss.rb
+++ b/lib/install/tailwindcss.rb
@@ -7,8 +7,10 @@ if APPLICATION_LAYOUT_PATH.exist?
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
   ERB
 
-  insert_into_file APPLICATION_LAYOUT_PATH.to_s, %(    <main class="container mx-auto mt-28 px-5 flex">\n  ), before: CENTERING_CONTAINER_INSERTION_POINT
-  insert_into_file APPLICATION_LAYOUT_PATH.to_s, %(\n    </main>),  after: CENTERING_CONTAINER_INSERTION_POINT
+  if File.open(APPLICATION_LAYOUT_PATH).read =~ /<body>\n\s*<%= yield %>\n\s*<\/body>/
+    insert_into_file APPLICATION_LAYOUT_PATH.to_s, %(    <main class="container mx-auto mt-28 px-5 flex">\n  ), before: CENTERING_CONTAINER_INSERTION_POINT
+    insert_into_file APPLICATION_LAYOUT_PATH.to_s, %(\n    </main>),  after: CENTERING_CONTAINER_INSERTION_POINT
+  end
 else
   say "Default application.html.erb is missing!", :red
   say %(        Add <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %> within the <head> tag in your custom layout.)


### PR DESCRIPTION
This addresses and closes #139.

Currently, the installer adds a `<main>` element around `<%= yield %>` in `application.html.erb`. This is ok for new projects, but it's annoying for projects that add this gem later on since they likely already have changed their `application.html.erb` and installing the gem breaks the layout.

This proposed change first checks if `application.html.erb` looks standard around `<%= yield %>`, and only in that case wraps it in a `<main>` element.