### PR TITLE
update build.rake in favor of using propshaft

### DIFF
--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -12,7 +12,11 @@ namespace :tailwindcss do
   end
 end
 
-Rake::Task["assets:precompile"].enhance(["tailwindcss:build"])
+if Rake::Task.task_defined?('assets:precompile') 
+  Rake::Task["assets:precompile"].enhance(["tailwindcss:build"]) 
+else 
+  Rake::Task["build"].enhance(["tailwindcss:build"]) 
+end
 
 if Rake::Task.task_defined?("test:prepare")
   Rake::Task["test:prepare"].enhance(["tailwindcss:build"])


### PR DESCRIPTION
after deprecation of sprockets and implementation of propshaft
inside an engine or a rails app 
the task assets:precompile is not available 
task tailwindcss:build must be enhance the build task instead.