### PR TITLE
update build.rake in favor of using propshaft #166

### DIFF
--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -12,7 +12,7 @@ namespace :tailwindcss do
   end
 end
 
-Rake::Task["assets:precompile"].enhance(["tailwindcss:build"])
+Rake::Task["assets:precompile"].enhance(["tailwindcss:build"]) if Rake::Task.task_defined?('assets:precompile')
 
 if Rake::Task.task_defined?("test:prepare")
   Rake::Task["test:prepare"].enhance(["tailwindcss:build"])

--- a/lib/tasks/clobber.rake
+++ b/lib/tasks/clobber.rake
@@ -5,4 +5,4 @@ namespace :tailwindcss do
   end
 end
 
-Rake::Task["assets:clobber"].enhance(["tailwindcss:clobber"])
+Rake::Task["assets:clobber"].enhance(["tailwindcss:clobber"]) if Rake::Task.task_defined?('assets:precompile') && Rake::Task.task_defined?('clober_assets')


### PR DESCRIPTION
the changes in the current PR avoid using sprockets in engines or Rails applications when using the propshaft gem

if somebody still wants to compile the assets the user can tailwindcss:build and keep working with propshaft