### PR TITLE
Enable polling support for tailwindcss cli

### DIFF
--- a/lib/install/Procfile.dev
+++ b/lib/install/Procfile.dev
@@ -1,2 +1,3 @@
 web: bin/rails server -p 3000
 css: bin/rails tailwindcss:watch
+css_polling: bin/rails tailwindcss:poll

--- a/lib/install/dev
+++ b/lib/install/dev
@@ -6,4 +6,18 @@ then
   gem install foreman
 fi
 
-foreman start -f Procfile.dev
+while getopts p: option
+do 
+  case "${option}"
+    in
+    p)polling=1;;
+    *);;
+  esac
+done
+
+if [ $polling -eq 1 ]
+then
+  foreman start -f Procfile.dev -m all=1,css=0
+else 
+  foreman start -f Procfile.dev -m all=1,css_polling=0
+fi

--- a/lib/install/dev
+++ b/lib/install/dev
@@ -6,7 +6,7 @@ then
   gem install foreman
 fi
 
-while getopts p: option
+while getopts "p" option
 do 
   case "${option}"
     in
@@ -17,6 +17,7 @@ done
 
 if [ $polling -eq 1 ]
 then
+  echo "[INFO] Enabled polling for css processing!"
   foreman start -f Procfile.dev -m all=1,css=0
 else 
   foreman start -f Procfile.dev -m all=1,css_polling=0

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -6,9 +6,14 @@ namespace :tailwindcss do
     system TAILWIND_COMPILE_COMMAND
   end
 
-  desc "Watch and build your Tailwind CSS on file changes"
+  desc "Watch and build your Tailwind CSS on file changes (using filesystem events)"
   task :watch do
     system "#{TAILWIND_COMPILE_COMMAND} -w"
+  end
+  
+  desc "Watch and build your Tailwind CSS on file changes (using polling)"
+  task :poll do
+    system "#{TAILWIND_COMPILE_COMMAND} -p"
   end
 end
 


### PR DESCRIPTION
### Reasoning
Due to an WSL2 issue (https://github.com/microsoft/WSL/issues/4739) the watch mechanism of the tailwindcss cli will not work on all potential developer setups. Especially when using vscode-devcontainers and keeping the code in the mounted directory. (assumed default behavior)
The recommended work around is to use polling instead of the normal inotify based watch mechanism.

### Changes
* This pull request will add a new task to tailwindcss-rails to use the polling option instead of the watch option
* A parameter is added to the ./bin/dev script, to switch between watch and poll mechanism
* Default behavior of tailwindcss-rails remains unchanged