### PR TITLE
Docs: Add notes for running tailwindcss:watch in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The installer will create your Tailwind input file in `app/assets/stylesheets/ap
 
 If you need to use a custom input or output file, you can run `bundle exec tailwindcss` to access the platform-specific executable, and give it your own build options.
 
-When you're developing your application, you want to run Tailwind in watch mode, so changes are automatically reflected in the generated CSS output. You can do this either by running `rails tailwindcss:watch` as a separate process, or by running `./bin/dev` which uses [foreman](https://github.com/ddollar/foreman) to starts both the Tailwind watch process and the rails server in development mode.
+When you're developing your application, you want to run Tailwind in watch mode, so changes are automatically reflected in the generated CSS output. You can do this either by running `rails tailwindcss:watch` as a separate process, or by running `./bin/dev` which uses [foreman](https://github.com/ddollar/foreman) to starts both the Tailwind watch process and the rails server in development mode. If you are running `rails tailwindcss:watch` as a process in a Docker container, set `tty: true` in `docker-compose.yml` for the appropriate container to keep the watch process running.
 
 
 ## Installation
@@ -81,11 +81,6 @@ See https://bundler.io/man/bundle-config.1.html for more information.
 ### "No such file or directory" running on Alpine (musl)
 
 When running `tailwindcss` on an Alpine system, some users report a "No such file or directory" error message.
-
-
-### Running the TailwindCSS watch command in Docker
-
-In order to run `bin/rails tailwindcss:watch` from a process, set `tty: true` in `docker-compose.yml` for the appropriate container.
 
 
 #### Install gnu libc compatibility

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ See https://bundler.io/man/bundle-config.1.html for more information.
 When running `tailwindcss` on an Alpine system, some users report a "No such file or directory" error message.
 
 
+### Running the TailwindCSS watch command in Docker
+
+In order to run `bin/rails tailwindcss:watch` from a process, set `tty: true` in `docker-compose.yml` for the appropriate container.
+
+
 #### Install gnu libc compatibility
 
 The cause of this is the upstream `tailwindcss` binary executables being built on a gnu libc system, making them incompatible with standard musl libc systems.


### PR DESCRIPTION
While running `bin/rails tailwindcss:watch` from within a `Procfile`, it was noticed that the command returns an exit 0 status if this is happening from within a Docker container.

See https://github.com/tailwindlabs/tailwindcss/issues/5324 for same problem and solution.

This may present as a gotcha for those running their Rails app from `docker-compose.yml`. Suggestion here to add this useful piece of information in the README.

