### PR TITLE
support x64-mingw-ucrt for Ruby 3.1 users (#172)

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["ruby", "x64-mingw32", "x86_64-darwin", "x86_64-linux"]
+        platform: ["ruby", "x64-mingw32", "x64-mingw-ucrt", "x86_64-darwin", "x86_64-linux"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -73,6 +73,20 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: gem-x64-mingw32
+          path: pkg
+      - run: "gem install pkg/tailwindcss-rails-*.gem"
+      - run: "tailwindcss --help"
+
+  windows-ucrt-install:
+    needs: ["package"]
+    runs-on: windows-2022
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+      - uses: actions/download-artifact@v2
+        with:
+          name: gem-x64-mingw-ucrt
           path: pkg
       - run: "gem install pkg/tailwindcss-rails-*.gem"
       - run: "tailwindcss --help"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,10 +57,10 @@ GEM
       mini_mime (>= 0.1.1)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.8.0)
     minitest (5.14.4)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     racc (1.6.0)
     rack (2.2.3)
@@ -96,4 +96,4 @@ DEPENDENCIES
   tailwindcss-rails!
 
 BUNDLED WITH
-   2.2.32
+   2.3.14

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Some users are reporting this error even when running on one of the supported na
 
 - arm64-darwin
 - x64-mingw32
+- x64-mingw-ucrt
 - x86_64-darwin
 - x86_64-linux
 - aarch64-linux

--- a/lib/tailwindcss/upstream.rb
+++ b/lib/tailwindcss/upstream.rb
@@ -7,6 +7,7 @@ module Tailwindcss
     NATIVE_PLATFORMS = {
       "arm64-darwin" => "tailwindcss-macos-arm64",
       "x64-mingw32" => "tailwindcss-windows-x64.exe",
+      "x64-mingw-ucrt" => "tailwindcss-windows-x64.exe",
       "x86_64-darwin" => "tailwindcss-macos-x64",
       "x86_64-linux" => "tailwindcss-linux-x64",
       "aarch64-linux" => "tailwindcss-linux-arm64",

--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -16,6 +16,12 @@
 #  binary and executes it. Note that this script is required because rubygems requires that
 #  executables declared in a gemspec must be Ruby scripts.
 #
+#  Windows support note: we ship the same executable in two gems, the `x64-mingw32` and
+#  `x64-mingw-ucrt` flavors because Ruby < 3.1 uses the MSCVRT runtime libraries, and Ruby >= 3.1
+#  uses the UCRT runtime libraries. You can read more about this change here:
+#
+#     https://rubyinstaller.org/2021/12/31/rubyinstaller-3.1.0-1-released.html
+#
 #  As a concrete example, an x86_64-linux system will see these files on disk after installing
 #  tailwindcss-rails-1.x.x-x86_64-linux.gem:
 #
@@ -30,6 +36,7 @@
 #  - pkg/tailwindcss-rails-1.0.0-aarch64-linux.gem
 #  - pkg/tailwindcss-rails-1.0.0-arm64-darwin.gem
 #  - pkg/tailwindcss-rails-1.0.0-x64-mingw32.gem
+#  - pkg/tailwindcss-rails-1.0.0-x64-mingw-ucrt.gem
 #  - pkg/tailwindcss-rails-1.0.0-x86_64-darwin.gem
 #  - pkg/tailwindcss-rails-1.0.0-x86_64-linux.gem
 # 
@@ -43,6 +50,7 @@
 #  - rake gem:aarch64-linux  # Build the aarch64-linux gem
 #  - rake gem:arm64-darwin   # Build the arm64-darwin gem
 #  - rake gem:x64-mingw32    # Build the x64-mingw32 gem
+#  - rake gem:x64-mingw-ucrt # Build the x64-mingw-ucrt gem
 #  - rake gem:x86_64-darwin  # Build the x86_64-darwin gem
 #  - rake gem:x86_64-linux   # Build the x86_64-linux gem
 #  - rake download           # Download all tailwindcss binaries


### PR DESCRIPTION
Windows support note: we ship the same executable in two gems, the `x64-mingw32` and `x64-mingw-ucrt` flavors because Ruby < 3.1 uses the MSCVRT runtime libraries, and Ruby >= 3.1 uses the UCRT runtime libraries.

You can read more about this change here:

> https://rubyinstaller.org/2021/12/31/rubyinstaller-3.1.0-1-released.html

Closes #172 