### PR TITLE
Add the `public/*.html` path to tailwind content config:

### DIFF
--- a/lib/install/tailwind.config.js
+++ b/lib/install/tailwind.config.js
@@ -2,6 +2,7 @@ const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
   content: [
+    './public/*.html',
     './app/helpers/**/*.rb',
     './app/javascript/**/*.js',
     './app/views/**/*.{erb,haml,html,slim}'


### PR DESCRIPTION
Add the `public/*.html` path to tailwind content config:

- It's pretty standard to have to customize the style of the default
  Rails 404, 422 and 500 page.
  This PR adds the path to those files to be able to style them with
  tailwind.