### PR TITLE
Make config path configurable

### DIFF
--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -1,4 +1,9 @@
-TAILWIND_COMPILE_COMMAND = "#{RbConfig.ruby} #{Pathname.new(__dir__).to_s}/../../exe/tailwindcss -i '#{Rails.root.join("app/assets/stylesheets/application.tailwind.css")}' -o '#{Rails.root.join("app/assets/builds/tailwind.css")}' -c '#{Rails.root.join("config/tailwind.config.js")}' --minify"
+TAILWIND_COMPILE_COMMAND = "#{RbConfig.ruby} "\
+  "#{Pathname.new(__dir__)}/../../exe/tailwindcss "\
+  "-i '#{Rails.root.join("app/assets/stylesheets/application.tailwind.css")}' "\
+  "-o '#{Rails.root.join("app/assets/builds/tailwind.css")}' "\
+  "-c '#{Rails.root.join(ENV.fetch("TAILWIND_CONFIG_PATH", "config/tailwind.config.js"))}' "\
+  "--minify"
 
 namespace :tailwindcss do
   desc "Build your Tailwind CSS"


### PR DESCRIPTION
I ran into an issue where I had to add `type: "module"` to my `package.json`. This led to an error running Tailwind:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/samuelnilsson/projects/plat_nisse/config/tailwind.config.js from /snapshot/tailwindcss/lib/cli.js not supported.
tailwind.config.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename tailwind.config.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in /Users/samuelnilsson/projects/plat_nisse/package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```

So, naturally, I renamed my config to end in .cjs but then I ran into:

```
Specified config file [REDACTED]/config/tailwind.config.js does not exist.
```

I found out this gem hardcodes the location of the config file and added the ability to use a custom path via an ENV variable. What do you think?

BTW, when testing my solution I pointed the gem to my fork on GitHub but ran into issues since it didn't contain the binaries. Is there a good way of solving that except for having to publish my own fork? I just went to the gem location and ran `rake package` locally but that won't fly in production.