### PR TITLE
use exec to run tailwind binary, so return codes pass through

### DIFF
--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -3,12 +3,12 @@ TAILWIND_COMPILE_COMMAND = "#{RbConfig.ruby} #{Pathname.new(__dir__).to_s}/../..
 namespace :tailwindcss do
   desc "Build your Tailwind CSS"
   task :build do
-    system TAILWIND_COMPILE_COMMAND
+    exec TAILWIND_COMPILE_COMMAND
   end
 
   desc "Watch and build your Tailwind CSS on file changes"
   task :watch do
-    system "#{TAILWIND_COMPILE_COMMAND} -w"
+    exec "#{TAILWIND_COMPILE_COMMAND} -w"
   end
 end
 


### PR DESCRIPTION
We are encountering issues where our CI pipeline can succeed without successfully building Tailwind. It appears this is possible because the `TAILWIND_COMPILE_COMMAND` is run with `system` and the return code is never checked. When problems occur, an error is printed to the console but the return code from running `rails tailwindcss:build` is still `0`.

Build errors, such as those caused by a version mismatch between the `tailwindcss-rails` and the corresponding binary gem, could cause a CI build to fail silently and lead to an unstyled site in production. Therefore I believe it is essential that these rake tasks pass through the return code.

Using `Kernel#exec` replaces the current process by running the given external command, thereby passing through any return codes. If this is unacceptable, another solution would be to add the `exception: true` flag to the `system` call.