### PR TITLE
Update to Tailwind CSS v3.1.8

### DIFF
--- a/lib/tailwindcss/upstream.rb
+++ b/lib/tailwindcss/upstream.rb
@@ -1,7 +1,7 @@
 module Tailwindcss
   # constants describing the upstream tailwindcss project
   module Upstream
-    VERSION = "v3.1.3"
+    VERSION = "v3.1.8"
 
     # rubygems platform name => upstream release filename
     NATIVE_PLATFORMS = {


### PR DESCRIPTION
I need the fix in https://github.com/tailwindlabs/tailwindcss/pull/8687 which was released in v3.1.4.

Has there been any thought in decoupling `tailwindcss-rails` releases from Tailwind? It would be nice to be able to use the latest Tailwind release without having to wait for `tailwindcss-rails` to be released.