### PR TITLE
address issue when running commands with #exec

### DIFF
--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -3,12 +3,12 @@ TAILWIND_COMPILE_COMMAND = "#{RbConfig.ruby} #{Pathname.new(__dir__).to_s}/../..
 namespace :tailwindcss do
   desc "Build your Tailwind CSS"
   task :build do
-    exec TAILWIND_COMPILE_COMMAND
+    system(TAILWIND_COMPILE_COMMAND, exception: true)
   end
 
   desc "Watch and build your Tailwind CSS on file changes"
   task :watch do
-    exec "#{TAILWIND_COMPILE_COMMAND} -w"
+    system "#{TAILWIND_COMPILE_COMMAND} -w"
   end
 end
 


### PR DESCRIPTION
This is a followup to https://github.com/rails/tailwindcss-rails/pull/181

After upgrading one of our repos to `2.0.11`, we unfortunately learned that running commands with `Kernel#exec` instead of `Kernel#system` introduces a failure in the `assets:precompile` pipeline. Due to `exec` hijacking the process from Ruby, subsequent steps will not run after the tailwind build completes.

This will probably need to be treated as an urgent bugfix as it may result in a failure of the asset pipeline to output images, javascript, etc.

This change effectively reverts #181, and adds the `exception: true` flag which will allow `#system` to raise when encountering failure codes.