### PR TITLE
Fix compatibility with musl (and thus Alpine linux) alongside latest rubygems v3.3.21

### DIFF
--- a/exe/tailwindcss
+++ b/exe/tailwindcss
@@ -4,6 +4,8 @@
 require "shellwords"
 require "tailwindcss/upstream"
 
+Gem::Platform.local.version = nil if Gem::Platform.local.version == "musl"
+
 supported_platforms = Tailwindcss::Upstream::NATIVE_PLATFORMS.keys
 platform = [:cpu, :os].map { |m| Gem::Platform.local.send(m) }.join("-")
 


### PR DESCRIPTION
A recent change (7 days ago) in ruby gems broke tailwindcss-rails compatibility with musl (and thus Alpine Linux). The change was shipped in rubygems v3.3.21.

Specifically, this change: https://github.com/rubygems/rubygems/pull/5852/files#diff-b2eac061756123f15f8d8e41075e4b8466a60945cad4e594b4eadf241d1a4089R28

Given the file modified in this PR is an executable, I *think* it's safe to mutate the local platform version without side effects. However, this probably deserves some further consideration.

The readme already mentions that `gcompat` is required if you're using tailwindcss-rails with musl. I did consider displaying a warning if `Gem::Platform.local.version` is `musl`. But, short of looking to see if `gcompat` is installed, I'm not sure how we would prevent the warning from displaying needlessly (already installed). In any case, a warning along those lines could be added in another PR.