### PR TITLE
fix: ship an x86_64-linux-musl platform gem

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["ruby", "x64-mingw32", "x64-mingw-ucrt", "x86_64-darwin", "x86_64-linux"]
+        platform: ["ruby", "x64-mingw32", "x64-mingw-ucrt", "x86_64-darwin", "x86_64-linux", "x86_64-linux-musl"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -45,6 +45,19 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: gem-x86_64-linux
+          path: pkg
+      - run: "gem install pkg/tailwindcss-rails-*.gem"
+      - run: "tailwindcss --help"
+
+  linux-musl-install:
+    needs: ["package"]
+    runs-on: ubuntu-latest
+    container:
+      image: ruby:3.1-alpine
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: gem-x86_64-linux-musl
           path: pkg
       - run: "gem install pkg/tailwindcss-rails-*.gem"
       - run: "tailwindcss --help"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Some users are reporting this error even when running on one of the supported na
 - x64-mingw-ucrt
 - x86_64-darwin
 - x86_64-linux
+- x86_64-linux-musl
 - aarch64-linux
 
 #### Check Bundler PLATFORMS

--- a/lib/tailwindcss/upstream.rb
+++ b/lib/tailwindcss/upstream.rb
@@ -10,6 +10,7 @@ module Tailwindcss
       "x64-mingw-ucrt" => "tailwindcss-windows-x64.exe",
       "x86_64-darwin" => "tailwindcss-macos-x64",
       "x86_64-linux" => "tailwindcss-linux-x64",
+      "x86_64-linux-musl" => "tailwindcss-linux-x64",
       "aarch64-linux" => "tailwindcss-linux-arm64",
     }
   end

--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -39,6 +39,7 @@
 #  - pkg/tailwindcss-rails-1.0.0-x64-mingw-ucrt.gem
 #  - pkg/tailwindcss-rails-1.0.0-x86_64-darwin.gem
 #  - pkg/tailwindcss-rails-1.0.0-x86_64-linux.gem
+#  - pkg/tailwindcss-rails-1.0.0-x86_64-linux-musl.gem
 # 
 #  Note that in addition to the native gems, a vanilla "ruby" gem will also be created without
 #  either the `exe/tailwindcss` script or a binary executable present.
@@ -46,14 +47,15 @@
 #
 #  New rake tasks created:
 #
-#  - rake gem:ruby           # Build the ruby gem
-#  - rake gem:aarch64-linux  # Build the aarch64-linux gem
-#  - rake gem:arm64-darwin   # Build the arm64-darwin gem
-#  - rake gem:x64-mingw32    # Build the x64-mingw32 gem
-#  - rake gem:x64-mingw-ucrt # Build the x64-mingw-ucrt gem
-#  - rake gem:x86_64-darwin  # Build the x86_64-darwin gem
-#  - rake gem:x86_64-linux   # Build the x86_64-linux gem
-#  - rake download           # Download all tailwindcss binaries
+#  - rake gem:ruby              # Build the ruby gem
+#  - rake gem:aarch64-linux     # Build the aarch64-linux gem
+#  - rake gem:arm64-darwin      # Build the arm64-darwin gem
+#  - rake gem:x64-mingw32       # Build the x64-mingw32 gem
+#  - rake gem:x64-mingw-ucrt    # Build the x64-mingw-ucrt gem
+#  - rake gem:x86_64-darwin     # Build the x86_64-darwin gem
+#  - rake gem:x86_64-linux      # Build the x86_64-linux gem
+#  - rake gem:x86_64-linux-musl # Build the x86_64-linux gem
+#  - rake download              # Download all tailwindcss binaries
 #
 #  Modified rake tasks:
 #


### PR DESCRIPTION
This was not strictly necessary before now because musl platforms have
always used the generic platform gem, but recent changes in rubygems
and bundler introduced new behaviors around libc flavors, and so we're
going the extra mile here to be explicit.

See #192 for context, also see
https://github.com/rubygems/rubygems/pull/5875
