### PR TITLE
feat: generate unminified assets with `debug` task param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 
 ## Unreleased
 
-* Correctly handle paths with embedded spaces. [#184](https://github.com/rails/tailwindcss-rails/issues/184)
+* Correctly handle paths with embedded spaces. [#184](https://github.com/rails/tailwindcss-rails/issues/184) by [@flavorjones](https://github.com/flavorjones)
+* Rake tasks accept a `debug` argument to generate unminified assets, e.g. `tailwindcss:build[debug]`. [#198](https://github.com/rails/tailwindcss-rails/pull/198) by [@flavorjones](https://github.com/flavorjones)
 
 
 ## v2.0.12 / 2022-08-10

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ You can customize the Tailwind build through the `config/tailwind.config.js` fil
 
 The installer will create your Tailwind input file in `app/assets/stylesheets/application.tailwind.css`. This is where you import the plugins you want to use, and where you can setup your custom `@apply` rules. When you run `rails tailwindcss:build`, this input file will be used to generate the output in `app/assets/builds/tailwind.css`. That's the output CSS that you'll include in your app (the installer automatically configures this, alongside the Inter font as well).
 
-If you need to use a custom input or output file, you can run `bundle exec tailwindcss` to access the platform-specific executable, and give it your own build options.
+**If you need to use a custom input or output file**, you can run `bundle exec tailwindcss` to access the platform-specific executable, and give it your own build options.
 
-When you're developing your application, you want to run Tailwind in watch mode, so changes are automatically reflected in the generated CSS output. You can do this either by running `rails tailwindcss:watch` as a separate process, or by running `./bin/dev` which uses [foreman](https://github.com/ddollar/foreman) to starts both the Tailwind watch process and the rails server in development mode. If you are running `rails tailwindcss:watch` as a process in a Docker container, set `tty: true` in `docker-compose.yml` for the appropriate container to keep the watch process running.
+**When you're developing your application**, you want to run Tailwind in watch mode, so changes are automatically reflected in the generated CSS output. You can do this either by running `rails tailwindcss:watch` as a separate process, or by running `./bin/dev` which uses [foreman](https://github.com/ddollar/foreman) to starts both the Tailwind watch process and the rails server in development mode. If you are running `rails tailwindcss:watch` as a process in a Docker container, set `tty: true` in `docker-compose.yml` for the appropriate container to keep the watch process running.
+
+**If you want unminified assets**, you can pass the `debug` parameter to the rake task, i.e. `rails tailwindcss:build[debug]` or `rails tailwindcss:watch[debug]`.
 
 
 ## Installation

--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -55,14 +55,15 @@ module Tailwindcss
         exe_path
       end
 
-      def compile_command(**kwargs)
+      def compile_command(debug: false, **kwargs)
         [
           executable(**kwargs),
           "-i", Rails.root.join("app/assets/stylesheets/application.tailwind.css").to_s,
           "-o", Rails.root.join("app/assets/builds/tailwind.css").to_s,
           "-c", Rails.root.join("config/tailwind.config.js").to_s,
-          "--minify",
-        ]
+        ].tap do |command|
+          command << "--minify" unless debug
+        end
       end
 
       def watch_command(**kwargs)

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -1,14 +1,16 @@
 namespace :tailwindcss do
   desc "Build your Tailwind CSS"
-  task :build do
-    command = Tailwindcss::Commands.compile_command
+  task :build do |_, args|
+    debug = args.extras.include?("debug")
+    command = Tailwindcss::Commands.compile_command(debug: debug)
     puts command.inspect
     system(*command, exception: true)
   end
 
   desc "Watch and build your Tailwind CSS on file changes"
-  task :watch do
-    command = Tailwindcss::Commands.watch_command
+  task :watch do |_, args|
+    debug = args.extras.include?("debug")
+    command = Tailwindcss::Commands.watch_command(debug: debug)
     puts command.inspect
     system(*command)
   end

--- a/test/lib/tailwindcss/commands_test.rb
+++ b/test/lib/tailwindcss/commands_test.rb
@@ -48,6 +48,12 @@ class Tailwindcss::CommandsTest < ActiveSupport::TestCase
         actual = Tailwindcss::Commands.compile_command(exe_path: dir)
         assert_kind_of(Array, actual)
         assert_equal(executable, actual.first)
+        assert_includes(actual, "--minify")
+
+        actual = Tailwindcss::Commands.compile_command(exe_path: dir, debug: true)
+        assert_kind_of(Array, actual)
+        assert_equal(executable, actual.first)
+        refute_includes(actual, "--minify")
       end
     end
   end
@@ -59,6 +65,13 @@ class Tailwindcss::CommandsTest < ActiveSupport::TestCase
         assert_kind_of(Array, actual)
         assert_equal(executable, actual.first)
         assert_includes(actual, "-w")
+        assert_includes(actual, "--minify")
+
+        actual = Tailwindcss::Commands.watch_command(exe_path: dir, debug: true)
+        assert_kind_of(Array, actual)
+        assert_equal(executable, actual.first)
+        assert_includes(actual, "-w")
+        refute_includes(actual, "--minify")
       end
     end
   end


### PR DESCRIPTION
Suggested by #163, this PR implements a debug "option" via rake task parameters.

Users can run `rails tailwindcss:build[debug]` or `rails tailwindcss:watch[debug]` to generate unminified assets.