### PR TITLE
dev: remove sqlite3 and add native platforms to the Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gemspec
 
-gem "sqlite3"
 gem "debug", ">= 1.0.0"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,10 @@ GEM
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-linux)
+      racc (~> 1.4)
     racc (1.6.0)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -80,7 +84,6 @@ GEM
     rake (13.0.6)
     reline (0.2.7)
       io-console (~> 0.5)
-    sqlite3 (1.4.2)
     thor (1.2.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -88,11 +91,12 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   actionmailer (>= 6.0.0)
   debug (>= 1.0.0)
-  sqlite3
   tailwindcss-rails!
 
 BUNDLED WITH


### PR DESCRIPTION
The need for sqlite3 was removed in 6f275f0.

Adding the same native platforms as `rails/rails`.