### PR TITLE
Unify `bin/dev` script with other js/css installers

### DIFF
--- a/lib/install/dev
+++ b/lib/install/dev
@@ -1,9 +1,8 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-if ! command -v foreman &> /dev/null
-then
+if ! gem list foreman -i --silent; then
   echo "Installing foreman..."
   gem install foreman
 fi
 
-foreman start -f Procfile.dev
+exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
In a similar manner to https://github.com/rails/dartsass-rails/pull/35.

This Pull Request streamlines the content of the `bin/dev` script across `rails/tailwindcss-rails`, `rails/dartsass-rails`, `rails/jsbundling-rails` and `rails/cssbundling-rails` so you don't run into conflicts when running multiple installers:

```
❯ rails tailwindcss:install
Add Tailwindcss include tags and container element in application layout
    insert  app/views/layouts/application.html.erb

Build into app/assets/builds
    exist  app/assets/builds
    identical  app/assets/builds/.keep
    append  Procfile.dev

Add bin/dev to start foreman
    conflict  bin/dev

Overwrite /Users/marcoroth/Development/project/bin/dev? (enter "h" for help) [Ynaqdhm]
```

This PR applies the changes from https://github.com/rails/cssbundling-rails/pull/93 and https://github.com/rails/cssbundling-rails/pull/98

