### PR TITLE
Update upstream tailwindcss version 3.2.2 -> 3.2.3

### DIFF
--- a/lib/tailwindcss/upstream.rb
+++ b/lib/tailwindcss/upstream.rb
@@ -1,7 +1,7 @@
 module Tailwindcss
   # constants describing the upstream tailwindcss project
   module Upstream
-    VERSION = "v3.2.2"
+    VERSION = "v3.2.3"
 
     # rubygems platform name => upstream release filename
     NATIVE_PLATFORMS = {


### PR DESCRIPTION
This update, among other things, fixes a bug with using "raw" content in the tailwind config (https://github.com/tailwindlabs/tailwindcss/pull/9773) which I use through this gem to output tailwind styles for user supplied markup.

Full release notes: https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.2.3