### PR TITLE
`verbose` arg for build commands

### DIFF
--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -3,7 +3,7 @@ namespace :tailwindcss do
   task :build do |_, args|
     debug = args.extras.include?("debug")
     command = Tailwindcss::Commands.compile_command(debug: debug)
-    puts command.inspect
+    puts command.inspect if args.extras.include?("verbose")
     system(*command, exception: true)
   end
 
@@ -12,7 +12,7 @@ namespace :tailwindcss do
     debug = args.extras.include?("debug")
     poll = args.extras.include?("poll")
     command = Tailwindcss::Commands.watch_command(debug: debug, poll: poll)
-    puts command.inspect
+    puts command.inspect if args.extras.include?("verbose")
     system(*command)
   end
 end


### PR DESCRIPTION
By default, removes the verbose log line when running a Tailwind build. This isn't really needed most of the time. You can use the `verbose` option to include it.

```
% bin/rake "tailwindcss:build[verbose]"
["/Users/alex/.rvm/gems/ruby-3.1.2/gems/tailwindcss-rails-2.0.21-x86_64-darwin/exe/x86_64-darwin/tailwindcss", "-i", "/Users/alex/Code/foo/app/assets/stylesheets/application.tailwind.css", "-o", "/Users/alex/Code/foo/app/assets/builds/tailwind.css", "-c", "/Users/alex/Code/foo/config/tailwind.config.js", "--minify"]

Rebuilding...

Done in 480ms.

% bin/rake tailwindcss:build

Rebuilding...

Done in 500ms.
```