### PR TITLE
Prioritize custom view templates

### DIFF
--- a/lib/generators/tailwindcss/scaffold/scaffold_generator.rb
+++ b/lib/generators/tailwindcss/scaffold/scaffold_generator.rb
@@ -6,7 +6,16 @@ module Tailwindcss
     class ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
       include Rails::Generators::ResourceHelpers
 
-      source_root File.expand_path("../templates", __FILE__)
+
+      def self.source_root
+        fallback_path=File.expand_path("../templates", __FILE__)
+        if Rails.root.nil?
+          return fallback_path
+        else
+          custom_scaffold_templates_path = File.join(Rails.root,"lib", "templates", "erb", "scaffold")
+          return Dir.exist?(custom_scaffold_templates_path)? custom_scaffold_templates_path : fallback_path
+        end
+      end
 
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
 


### PR DESCRIPTION
Current behavior:
Custom templates are ignored by the tailwindcss-rails generator

Expected behavior:
View templates under "#{RAILS_ROOT}/lib/templates/erb/scaffold" should be prioritized by the generator.

https://github.com/rails/tailwindcss-rails/issues/164