### PR TITLE
allow users to always generate unminified CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ If you want unminified assets, you can pass a `debug` argument to the rake task,
 Note that you can combine task options, e.g. `rails tailwindcss:watch[debug,poll]`.
 
 
+### Never minify assets
+
+If you _always_ want unminified assets, you can set the environment variable `TAILWINDCSS_RAILS_NO_MINIFY` to something that [looks truthy](https://api.rubyonrails.org/classes/ActiveModel/Type/Boolean.html) (hint: "t" or "1" will work).
+
+
 ### Custom inputs or outputs
 
 If you need to use a custom input or output file, you can run `bundle exec tailwindcss` to access the platform-specific executable, and give it your own build options.

--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -74,11 +74,20 @@ module Tailwindcss
       end
 
       def debug_option(rake_task_args_extras)
-        rake_task_args_extras.include?("debug")
+        rake_task_args_extras.include?("debug") || truthy_string_value(ENV['TAILWINDCSS_RAILS_NO_MINIFY'])
       end
 
       def poll_option(rake_task_args_extras)
         rake_task_args_extras.include?("poll")
+      end
+
+      def truthy_string_value(value)
+        if !value.present? ||
+           ["f", "F", "false", "FALSE", "off", "OFF", "0"].include?(value)
+          false
+        else
+          true
+        end
       end
     end
   end

--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -72,6 +72,14 @@ module Tailwindcss
           command << "-p" if poll
         end
       end
+
+      def debug_option(rake_task_args_extras)
+        rake_task_args_extras.include?("debug")
+      end
+
+      def poll_option(rake_task_args_extras)
+        rake_task_args_extras.include?("poll")
+      end
     end
   end
 end

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -1,7 +1,7 @@
 namespace :tailwindcss do
   desc "Build your Tailwind CSS"
   task :build do |_, args|
-    debug = args.extras.include?("debug")
+    debug = Tailwindcss::Commands.debug_option(args.extras)
     command = Tailwindcss::Commands.compile_command(debug: debug)
     puts command.inspect if args.extras.include?("verbose")
     system(*command, exception: true)
@@ -9,8 +9,8 @@ namespace :tailwindcss do
 
   desc "Watch and build your Tailwind CSS on file changes"
   task :watch do |_, args|
-    debug = args.extras.include?("debug")
-    poll = args.extras.include?("poll")
+    debug = Tailwindcss::Commands.debug_option(args.extras)
+    poll = Tailwindcss::Commands.poll_option(args.extras)
     command = Tailwindcss::Commands.watch_command(debug: debug, poll: poll)
     puts command.inspect if args.extras.include?("verbose")
     system(*command)

--- a/test/lib/tailwindcss/commands_test.rb
+++ b/test/lib/tailwindcss/commands_test.rb
@@ -84,4 +84,16 @@ class Tailwindcss::CommandsTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test ".debug_option" do
+    refute(Tailwindcss::Commands.debug_option([]))
+    assert(Tailwindcss::Commands.debug_option(["debug"]))
+    refute(Tailwindcss::Commands.debug_option(["poll"]))
+  end
+
+  test ".poll_option" do
+    refute(Tailwindcss::Commands.poll_option([]))
+    refute(Tailwindcss::Commands.poll_option(["debug"]))
+    assert(Tailwindcss::Commands.poll_option(["poll"]))
+  end
 end


### PR DESCRIPTION
Discussed in #243.
Closes #244.

This PR allows users to set an environment variable `TAILWINDCSS_RAILS_NO_MINIFY` to turn off minification.
