### PR TITLE
feat: tailwind will not minify when Rails CSS compression is on

### DIFF
--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -62,7 +62,7 @@ module Tailwindcss
           "-o", Rails.root.join("app/assets/builds/tailwind.css").to_s,
           "-c", Rails.root.join("config/tailwind.config.js").to_s,
         ].tap do |command|
-          command << "--minify" unless debug
+          command << "--minify" unless (debug || rails_css_compressor?)
         end
       end
 
@@ -71,6 +71,10 @@ module Tailwindcss
           command << "-w"
           command << "-p" if poll
         end
+      end
+
+      def rails_css_compressor?
+        defined?(Rails) && Rails&.application&.config&.assets&.css_compressor.present?
       end
     end
   end

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -1,6 +1,6 @@
 namespace :tailwindcss do
   desc "Build your Tailwind CSS"
-  task :build do |_, args|
+  task build: :environment do |_, args|
     debug = args.extras.include?("debug")
     command = Tailwindcss::Commands.compile_command(debug: debug)
     puts command.inspect if args.extras.include?("verbose")
@@ -8,7 +8,7 @@ namespace :tailwindcss do
   end
 
   desc "Watch and build your Tailwind CSS on file changes"
-  task :watch do |_, args|
+  task watch: :environment do |_, args|
     debug = args.extras.include?("debug")
     poll = args.extras.include?("poll")
     command = Tailwindcss::Commands.watch_command(debug: debug, poll: poll)

--- a/test/lib/tailwindcss/commands_test.rb
+++ b/test/lib/tailwindcss/commands_test.rb
@@ -58,6 +58,24 @@ class Tailwindcss::CommandsTest < ActiveSupport::TestCase
     end
   end
 
+  test ".compile_command when Rails compression is on" do
+    mock_exe_directory("sparc-solaris2.8") do |dir, executable|
+      Rails.stub(:root, File) do # Rails.root won't work in this test suite
+        Tailwindcss::Commands.stub(:rails_css_compressor?, true) do
+          actual = Tailwindcss::Commands.compile_command(exe_path: dir)
+          assert_kind_of(Array, actual)
+          refute_includes(actual, "--minify")
+        end
+
+        Tailwindcss::Commands.stub(:rails_css_compressor?, false) do
+          actual = Tailwindcss::Commands.compile_command(exe_path: dir)
+          assert_kind_of(Array, actual)
+          assert_includes(actual, "--minify")
+        end
+      end
+    end
+  end
+
   test ".watch_command" do
     mock_exe_directory("sparc-solaris2.8") do |dir, executable|
       Rails.stub(:root, File) do # Rails.root won't work in this test suite


### PR DESCRIPTION
Looking for feedback on this approach.

This will avoid double-compression which breaks styles.

Fixes #243

See https://github.com/rails/rails/issues/47553