### PR TITLE
Added 2 official Tailwind plugins

### DIFF
--- a/lib/install/tailwind.config.js
+++ b/lib/install/tailwind.config.js
@@ -18,5 +18,7 @@ module.exports = {
     require('@tailwindcss/forms'),
     require('@tailwindcss/aspect-ratio'),
     require('@tailwindcss/typography'),
+    require('@tailwindcss/line-clamp'),
+    require('@tailwindcss/container-queries'),
   ]
 }


### PR DESCRIPTION
Tailwind has 5 official plugins but only the first 3 are installed by default. 

This pull request adds the final 2 plugins (line clamp and container queries) to the installer for config/tailwind.config.js.