### PR TITLE
Update tailwindcss to v3.3.0

### DIFF
--- a/lib/install/tailwind.config.js
+++ b/lib/install/tailwind.config.js
@@ -18,7 +18,6 @@ module.exports = {
     require('@tailwindcss/forms'),
     require('@tailwindcss/aspect-ratio'),
     require('@tailwindcss/typography'),
-    require('@tailwindcss/line-clamp'),
     require('@tailwindcss/container-queries'),
   ]
 }

--- a/lib/tailwindcss/upstream.rb
+++ b/lib/tailwindcss/upstream.rb
@@ -1,7 +1,7 @@
 module Tailwindcss
   # constants describing the upstream tailwindcss project
   module Upstream
-    VERSION = "v3.2.7"
+    VERSION = "v3.3.0"
 
     # rubygems platform name => upstream release filename
     NATIVE_PLATFORMS = {


### PR DESCRIPTION
https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.3.0

The line-clamp plugin is now baked into the framework itself: https://tailwindcss.com/blog/tailwindcss-v3-3