### PR TITLE
Updated TailwindCSS to v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+## v2.0.26 / 2023-03-29
+
+* Updated to [Tailwind CSS v3.3.0](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.3.0) by [@revans](https://github.com/revans).
+* Removed the `line-clamp` plugin as it is no longer needed in v3.3.0. It comes out of box now. (#258) by [@revans](https://github.com/revans).
+
 ## v2.0.25 / 2023-03-14
 
 * Installer now includes all 5 official Tailwind plugins (adding `line-clamp` and `container-queries`). (#254) by @Kentasmic

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    tailwindcss-rails (2.0.24)
+    tailwindcss-rails (2.0.26)
       railties (>= 6.0.0)
 
 GEM

--- a/lib/install/tailwind.config.js
+++ b/lib/install/tailwind.config.js
@@ -18,7 +18,6 @@ module.exports = {
     require('@tailwindcss/forms'),
     require('@tailwindcss/aspect-ratio'),
     require('@tailwindcss/typography'),
-    require('@tailwindcss/line-clamp'),
     require('@tailwindcss/container-queries'),
   ]
 }

--- a/lib/tailwindcss/upstream.rb
+++ b/lib/tailwindcss/upstream.rb
@@ -1,7 +1,7 @@
 module Tailwindcss
   # constants describing the upstream tailwindcss project
   module Upstream
-    VERSION = "v3.2.7"
+    VERSION = "v3.3.0"
 
     # rubygems platform name => upstream release filename
     NATIVE_PLATFORMS = {

--- a/lib/tailwindcss/version.rb
+++ b/lib/tailwindcss/version.rb
@@ -1,3 +1,3 @@
 module Tailwindcss
-  VERSION = "2.0.25"
+  VERSION = "2.0.26"
 end


### PR DESCRIPTION
## TailwindCSS Version Update

Yesterday, TailwindCSS had a decent-size release with many new features and refactorings. This PR updates this project to the latest release of v3.3.0.

[TailwindCSS Release Notes](https://tailwindcss.com/blog/tailwindcss-v3-3#new-list-style-image-utilities)