### PR TITLE
feat: allow overriding executable with environment variable

### DIFF
--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -25,11 +25,17 @@ module Tailwindcss
           MESSAGE
         end
 
-        exe_path = Dir.glob(File.expand_path(File.join(exe_path, "*", "tailwindcss"))).find do |f|
-          Gem::Platform.match(Gem::Platform.new(File.basename(File.dirname(f))))
+        # Let the user override the executable path with an environment variable
+        # Useful for when running under Nix
+        exe_file = ENV["TAILWINDCSS_RAILS_EXECUTABLE_PATH"]
+
+        if exe_file.nil? || exe_file.empty?
+          exe_file = Dir.glob(File.expand_path(File.join(exe_path, "*", "tailwindcss"))).find do |f|
+            Gem::Platform.match(Gem::Platform.new(File.basename(File.dirname(f))))
+          end
         end
 
-        if exe_path.nil?
+        if exe_file.nil? || exe_file.empty?
           raise ExecutableNotFoundException, <<~MESSAGE
             Cannot find the tailwindcss executable for #{platform} in #{exe_path}
 
@@ -52,7 +58,7 @@ module Tailwindcss
           MESSAGE
         end
 
-        exe_path
+        exe_file
       end
 
       def compile_command(debug: false, **kwargs)

--- a/test/lib/tailwindcss/commands_test.rb
+++ b/test/lib/tailwindcss/commands_test.rb
@@ -26,6 +26,13 @@ class Tailwindcss::CommandsTest < ActiveSupport::TestCase
     end
   end
 
+  test ".executable accepts an override through the TAILWINDCSS_RAILS_EXECUTABLE_PATH environment variable" do
+    filename = "/nix/store/li4jwsd16y68yjyznbffaf98jccipg36-tailwindcss-3.2.7/bin/tailwindcss"
+    ENV["TAILWINDCSS_RAILS_EXECUTABLE_PATH"] = filename
+    assert_equal(filename, Tailwindcss::Commands.executable)
+    ENV["TAILWINDCSS_RAILS_EXECUTABLE_PATH"] = ""
+  end
+
   test ".executable raises UnsupportedPlatformException when we're not on a supported platform" do
     Gem::Platform.stub(:match, false) do # nothing is supported
       assert_raises(Tailwindcss::Commands::UnsupportedPlatformException) do


### PR DESCRIPTION
This allows users to provide a path to their own `tailwindcss` executable, which can be handy in cases where the pre-built ones won't work (e.g. in bundix-based Nix setups).

Closes #224
Replaces/closes #226