### PR TITLE
Handle `tailwindcss:watch[always]`

### DIFF
--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -83,9 +83,10 @@ module Tailwindcss
         end
       end
 
-      def watch_command(poll: false, **kwargs)
+      def watch_command(always: false, poll: false, **kwargs)
         compile_command(**kwargs).tap do |command|
           command << "-w"
+          command << "always" if always
           command << "-p" if poll
         end
       end

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -11,7 +11,8 @@ namespace :tailwindcss do
   task watch: :environment do |_, args|
     debug = args.extras.include?("debug")
     poll = args.extras.include?("poll")
-    command = Tailwindcss::Commands.watch_command(debug: debug, poll: poll)
+    always = args.extras.include?("always")
+    command = Tailwindcss::Commands.watch_command(always: always, debug: debug, poll: poll)
     puts command.inspect if args.extras.include?("verbose")
     system(*command)
   end

--- a/test/lib/tailwindcss/commands_test.rb
+++ b/test/lib/tailwindcss/commands_test.rb
@@ -165,8 +165,15 @@ class Tailwindcss::CommandsTest < ActiveSupport::TestCase
         assert_kind_of(Array, actual)
         assert_equal(executable, actual.first)
         assert_includes(actual, "-w")
+        refute_includes(actual, "always")
         assert_includes(actual, "-p")
         assert_includes(actual, "--minify")
+
+        actual = Tailwindcss::Commands.watch_command(exe_path: dir, always: true)
+        assert_kind_of(Array, actual)
+        assert_equal(executable, actual.first)
+        assert_includes(actual, "-w")
+        assert_includes(actual, "always")
       end
     end
   end


### PR DESCRIPTION
Passes `-w always` along to tailwindcss, which keeps the watch going even if stdin closes (https://github.com/tailwindlabs/tailwindcss/pull/9966).