### PR TITLE
Fix deprecation warnings in 3.5.0

### DIFF
--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -34,7 +34,7 @@ module Tailwindcss
             MESSAGE
           end
         else
-          if Tailwindcss::Upstream::NATIVE_PLATFORMS.keys.none? { |p| Gem::Platform.match(Gem::Platform.new(p)) }
+          if Tailwindcss::Upstream::NATIVE_PLATFORMS.keys.none? { |p| Gem::Platform.match_gem?(Gem::Platform.new(p), nil) }
             raise UnsupportedPlatformException, <<~MESSAGE
               tailwindcss-rails does not support the #{platform} platform
               Please install tailwindcss following instructions at https://tailwindcss.com/docs/installation
@@ -42,7 +42,7 @@ module Tailwindcss
           end
 
           exe_file = Dir.glob(File.expand_path(File.join(exe_path, "*", "tailwindcss"))).find do |f|
-            Gem::Platform.match(Gem::Platform.new(File.basename(File.dirname(f))))
+            Gem::Platform.match_gem?(Gem::Platform.new(File.basename(File.dirname(f))), nil)
           end
         end
 

--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -3,6 +3,7 @@ require_relative "upstream"
 module Tailwindcss
   module Commands
     DEFAULT_DIR = File.expand_path(File.join(__dir__, "..", "..", "exe"))
+    GEM_NAME = "tailwindcss-rails"
 
     # raised when the host platform is not supported by upstream tailwindcss's binary releases
     class UnsupportedPlatformException < StandardError
@@ -34,7 +35,7 @@ module Tailwindcss
             MESSAGE
           end
         else
-          if Tailwindcss::Upstream::NATIVE_PLATFORMS.keys.none? { |p| Gem::Platform.match_gem?(Gem::Platform.new(p), nil) }
+          if Tailwindcss::Upstream::NATIVE_PLATFORMS.keys.none? { |p| Gem::Platform.match_gem?(Gem::Platform.new(p), GEM_NAME) }
             raise UnsupportedPlatformException, <<~MESSAGE
               tailwindcss-rails does not support the #{platform} platform
               Please install tailwindcss following instructions at https://tailwindcss.com/docs/installation
@@ -42,7 +43,7 @@ module Tailwindcss
           end
 
           exe_file = Dir.glob(File.expand_path(File.join(exe_path, "*", "tailwindcss"))).find do |f|
-            Gem::Platform.match_gem?(Gem::Platform.new(File.basename(File.dirname(f))), nil)
+            Gem::Platform.match_gem?(Gem::Platform.new(File.basename(File.dirname(f))), GEM_NAME)
           end
         end
 

--- a/test/lib/tailwindcss/commands_test.rb
+++ b/test/lib/tailwindcss/commands_test.rb
@@ -7,7 +7,7 @@ class Tailwindcss::CommandsTest < ActiveSupport::TestCase
       FileUtils.mkdir(File.join(dir, platform))
       path = File.join(dir, platform, "tailwindcss")
       FileUtils.touch(path)
-      Gem::Platform.stub(:match, true) do
+      Gem::Platform.stub(:match_gem?, true) do
         yield(dir, path)
       end
     end
@@ -35,7 +35,7 @@ class Tailwindcss::CommandsTest < ActiveSupport::TestCase
   end
 
   test ".executable raises UnsupportedPlatformException when we're not on a supported platform" do
-    Gem::Platform.stub(:match, false) do # nothing is supported
+    Gem::Platform.stub(:match_gem?, false) do # nothing is supported
       assert_raises(Tailwindcss::Commands::UnsupportedPlatformException) do
         Tailwindcss::Commands.executable
       end
@@ -66,7 +66,7 @@ class Tailwindcss::CommandsTest < ActiveSupport::TestCase
   end
 
   test ".executable returns the executable in TAILWINDCSS_INSTALL_DIR when we're not on a supported platform" do
-    Gem::Platform.stub(:match, false) do # nothing is supported
+    Gem::Platform.stub(:match_gem?, false) do # nothing is supported
       mock_local_tailwindcss_install do |local_install_dir, expected|
         result = nil
         begin


### PR DESCRIPTION
Running Ruby 3.3.0-preview2 and Ruby Gems 3.5.0.dev I am seeing the following deprecation warning:

```
NOTE: Gem::Platform.match is deprecated; use Gem::Platform.match_spec? or match_gem? instead. It will be removed in Rubygems 4
Gem::Platform.match called from /Users/[me]/dev/tailwindcss-rails/lib/tailwindcss/commands.rb:37.
```

This patch replaces calls to `Gem::Platform#match` to `Gem::Platform#match_gem?` as recommended in [the source](https://github.com/rubygems/rubygems/blob/28f813ba97d6ed3a8ede427b0dc5e7fab47aa02f/lib/rubygems/platform.rb#L27).

This update passes `nil` as the second argument to `match_gem?`. The implementation of `match_gem?` appears to ignore the second argument (`gem_name`) and it's actually identical to the deprecated `match` method:

```ruby
  def self.match(platform)
    match_platforms?(platform, Gem.platforms)
  end

  def self.match_gem?(platform, gem_name)
    # NOTE: this method might be redefined by Ruby implementations to
    # customize behavior per RUBY_ENGINE, gem_name or other criteria.
    match_platforms?(platform, Gem.platforms)
  end
```

