### PR TITLE
Run the server with remote debugging enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## next / unreleased
+
+* Update Procfile.dev to run foreman with `--open` option allowing remote sessions with `rdbg --attach` by @duduribeiro
 
 ## v2.0.30 / 2023-07-13
 

--- a/lib/install/Procfile.dev
+++ b/lib/install/Procfile.dev
@@ -1,2 +1,2 @@
-web: bin/rails server -p 3000
+web: env RUBY_DEBUG_OPEN=true bin/rails server -p 3000
 css: bin/rails tailwindcss:watch


### PR DESCRIPTION
This commit adds the `--open` option so a remote session can be started using `rdbg --attach`. This allows to debug inside a foreman process.

This will replicate what we have on jsbundling-rails https://github.com/rails/jsbundling-rails/blob/main/lib/install/Procfile.dev#L1 and on cssbundling-rails https://github.com/rails/cssbundling-rails/blob/main/lib/install/Procfile_for_bun.dev#L1