### PR TITLE
Lazily load the debug gem

### DIFF
--- a/lib/install/Procfile.dev
+++ b/lib/install/Procfile.dev
@@ -1,2 +1,2 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails server
+web: bin/rails server
 css: bin/rails tailwindcss:watch

--- a/lib/install/Procfile.dev
+++ b/lib/install/Procfile.dev
@@ -1,2 +1,2 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails server -p 3000
+web: env RUBY_DEBUG_OPEN=true bin/rails server
 css: bin/rails tailwindcss:watch

--- a/lib/install/dev
+++ b/lib/install/dev
@@ -8,4 +8,9 @@ fi
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
 exec foreman start -f Procfile.dev "$@"

--- a/lib/install/dev
+++ b/lib/install/dev
@@ -5,4 +5,7 @@ if ! gem list foreman -i --silent; then
   gem install foreman
 fi
 
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
 exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
Fixes #291

Lazily load the `debug` gem in order to mitigate issues with docker environments such as `dip`.

Backport the port configuration so it allows overriding.
