### PR TITLE
dep: bump tailwindcss to v3.3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}
-          rubygems: latest
+          rubygems: "3.4.22" # last version to support Ruby 2.7
           bundler: latest
           bundler-cache: true
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: ["2.7", "3.0", "3.1", "3.2", "head"]
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## next / unreleased
+
+* Update to [Tailwind CSS v3.3.7](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.3.7) from v3.3.6 by @flavorjones
+
+
 ## v2.0.33 / 2023-12-09
 
 * Update to [Tailwind CSS v3.3.6](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.3.6) from v3.3.5 by @flavorjones

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,41 +1,42 @@
 PATH
   remote: .
   specs:
-    tailwindcss-rails (2.0.32)
+    tailwindcss-rails (2.0.33)
       railties (>= 6.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (7.1.0)
-      actionpack (= 7.1.0)
-      actionview (= 7.1.0)
-      activejob (= 7.1.0)
-      activesupport (= 7.1.0)
+    actionmailer (7.1.2)
+      actionpack (= 7.1.2)
+      actionview (= 7.1.2)
+      activejob (= 7.1.2)
+      activesupport (= 7.1.2)
       mail (~> 2.5, >= 2.5.4)
       net-imap
       net-pop
       net-smtp
       rails-dom-testing (~> 2.2)
-    actionpack (7.1.0)
-      actionview (= 7.1.0)
-      activesupport (= 7.1.0)
+    actionpack (7.1.2)
+      actionview (= 7.1.2)
+      activesupport (= 7.1.2)
       nokogiri (>= 1.8.5)
+      racc
       rack (>= 2.2.4)
       rack-session (>= 1.0.1)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    actionview (7.1.0)
-      activesupport (= 7.1.0)
+    actionview (7.1.2)
+      activesupport (= 7.1.2)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activejob (7.1.0)
-      activesupport (= 7.1.0)
+    activejob (7.1.2)
+      activesupport (= 7.1.2)
       globalid (>= 0.3.6)
-    activesupport (7.1.0)
+    activesupport (7.1.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -45,28 +46,28 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    base64 (0.1.1)
-    bigdecimal (3.1.4)
+    base64 (0.2.0)
+    bigdecimal (3.1.5)
     builder (3.2.4)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
     crass (1.0.6)
-    date (3.3.3)
-    debug (1.8.0)
-      irb (>= 1.5.0)
-      reline (>= 0.3.1)
-    drb (2.1.1)
+    date (3.3.4)
+    debug (1.9.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
+    drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    io-console (0.6.0)
-    irb (1.8.1)
+    io-console (0.7.1)
+    irb (1.10.1)
       rdoc
       reline (>= 0.3.8)
-    loofah (2.21.4)
+    loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -75,28 +76,28 @@ GEM
       net-pop
       net-smtp
     mini_mime (1.1.5)
-    mini_portile2 (2.8.4)
+    mini_portile2 (2.8.5)
     minitest (5.20.0)
-    mutex_m (0.1.2)
-    net-imap (0.4.1)
+    mutex_m (0.2.0)
+    net-imap (0.4.8)
       date
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.1)
+    net-protocol (0.2.2)
       timeout
     net-smtp (0.4.0)
       net-protocol
-    nokogiri (1.15.4)
+    nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-darwin)
+    nokogiri (1.15.5-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
+    nokogiri (1.15.5-x86_64-linux)
       racc (~> 1.4)
-    psych (5.1.0)
+    psych (5.1.2)
       stringio
-    racc (1.7.1)
+    racc (1.7.3)
     rack (3.0.8)
     rack-session (2.0.0)
       rack (>= 3.0.0)
@@ -112,23 +113,23 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (7.1.0)
-      actionpack (= 7.1.0)
-      activesupport (= 7.1.0)
+    railties (7.1.2)
+      actionpack (= 7.1.2)
+      activesupport (= 7.1.2)
       irb
       rackup (>= 1.0.0)
       rake (>= 12.2)
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
-    rake (13.0.6)
-    rdoc (6.5.0)
+    rake (13.1.0)
+    rdoc (6.6.2)
       psych (>= 4.0.0)
-    reline (0.3.9)
+    reline (0.4.1)
       io-console (~> 0.5)
     ruby2_keywords (0.0.5)
-    stringio (3.0.8)
-    thor (1.2.2)
-    timeout (0.4.0)
+    stringio (3.1.0)
+    thor (1.3.0)
+    timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     webrick (1.8.1)
@@ -145,4 +146,4 @@ DEPENDENCIES
   tailwindcss-rails!
 
 BUNDLED WITH
-   2.4.7
+   2.5.1

--- a/lib/tailwindcss/upstream.rb
+++ b/lib/tailwindcss/upstream.rb
@@ -1,7 +1,7 @@
 module Tailwindcss
   # constants describing the upstream tailwindcss project
   module Upstream
-    VERSION = "v3.3.6"
+    VERSION = "v3.3.7"
 
     # rubygems platform name => upstream release filename
     NATIVE_PLATFORMS = {


### PR DESCRIPTION
https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.3.7