### PR TITLE
fix: password form field classes

### DIFF
--- a/lib/generators/tailwindcss/scaffold/templates/_form.html.erb.tt
+++ b/lib/generators/tailwindcss/scaffold/templates/_form.html.erb.tt
@@ -15,7 +15,7 @@
   <div class="my-5">
 <% if attribute.password_digest? -%>
     <%%= form.label :password %>
-    <%%= form.password_field :password %>
+    <%%= form.password_field :password, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
 </div>
 
 <div class="my-5">


### PR DESCRIPTION
Fixes #304

Previously, form would render like:

![image](https://github.com/rails/tailwindcss-rails/assets/8207/30abce13-c2c2-4713-a5f2-9c276e826dee)


With this PR, form renders like:

![image](https://github.com/rails/tailwindcss-rails/assets/8207/81bbecbc-1d8a-4c44-9b86-a5d1112806df)
