### PR TITLE
Allow users to override scaffold generator templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Update to [Tailwind CSS v3.4.1](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.4.1) from v3.4.0 by @flavorjones
 * Fix `password` form field styling in generated scaffold forms. (#304, #307) @flavorjones
 * Fix namespaced mailer generation. (#272, #308) @flavorjones
+* Allow overriding the generator templates by placing application templates in either `lib/templates/tailwindcss/{scaffold,mailer,controller}` or `lib/templates/erb/{scaffold,mailer,controller}`. (#164, #314) @flavorjones
 
 
 ## v2.2.0 / 2023-01-04

--- a/lib/generators/tailwindcss/controller/controller_generator.rb
+++ b/lib/generators/tailwindcss/controller/controller_generator.rb
@@ -3,7 +3,7 @@ require "rails/generators/erb/controller/controller_generator"
 module Tailwindcss
   module Generators
     class ControllerGenerator < Erb::Generators::ControllerGenerator
-      source_root File.expand_path("../templates", __FILE__)
+      source_root File.expand_path("templates", __dir__)
     end
   end
 end

--- a/lib/generators/tailwindcss/controller/controller_generator.rb
+++ b/lib/generators/tailwindcss/controller/controller_generator.rb
@@ -4,6 +4,7 @@ module Tailwindcss
   module Generators
     class ControllerGenerator < Erb::Generators::ControllerGenerator
       source_root File.expand_path("templates", __dir__)
+      source_paths << "lib/templates/erb/controller"
     end
   end
 end

--- a/lib/generators/tailwindcss/mailer/mailer_generator.rb
+++ b/lib/generators/tailwindcss/mailer/mailer_generator.rb
@@ -3,7 +3,7 @@ require "rails/generators/erb/mailer/mailer_generator"
 module Tailwindcss
   module Generators
     class MailerGenerator < Erb::Generators::MailerGenerator
-      source_root File.expand_path("../templates", __FILE__)
+      source_root File.expand_path("templates", __dir__)
     end
   end
 end

--- a/lib/generators/tailwindcss/mailer/mailer_generator.rb
+++ b/lib/generators/tailwindcss/mailer/mailer_generator.rb
@@ -4,6 +4,7 @@ module Tailwindcss
   module Generators
     class MailerGenerator < Erb::Generators::MailerGenerator
       source_root File.expand_path("templates", __dir__)
+      source_paths << "lib/templates/erb/mailer"
     end
   end
 end

--- a/lib/generators/tailwindcss/scaffold/scaffold_generator.rb
+++ b/lib/generators/tailwindcss/scaffold/scaffold_generator.rb
@@ -7,6 +7,7 @@ module Tailwindcss
       include Rails::Generators::ResourceHelpers
 
       source_root File.expand_path("templates", __dir__)
+      source_paths << "lib/templates/erb/scaffold"
 
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
 

--- a/lib/generators/tailwindcss/scaffold/scaffold_generator.rb
+++ b/lib/generators/tailwindcss/scaffold/scaffold_generator.rb
@@ -6,7 +6,7 @@ module Tailwindcss
     class ScaffoldGenerator < Erb::Generators::ScaffoldGenerator
       include Rails::Generators::ResourceHelpers
 
-      source_root File.expand_path("../templates", __FILE__)
+      source_root File.expand_path("templates", __dir__)
 
       argument :attributes, type: :array, default: [], banner: "field:type field:type"
 

--- a/test/lib/generators/tailwindcss/controller_generator_test.rb
+++ b/test/lib/generators/tailwindcss/controller_generator_test.rb
@@ -9,8 +9,39 @@ class Tailwindcss::Generators::ControllerGeneratorTest < Rails::Generators::Test
 
   test "generates correct view templates" do
     run_generator
-    assert_file "app/views/messages/index.html.erb"
-    assert_file "app/views/messages/show.html.erb"
+
+    ["index", "show"].each do |view|
+      assert_file "app/views/messages/#{view}.html.erb"
+    end
+  end
+
+  test "generates correct view templates when namespaced" do
+    run_generator ["admin/messages", "index", "show"]
+
+    ["index", "show"].each do |view|
+      assert_file "app/views/admin/messages/#{view}.html.erb"
+    end
+  end
+
+  [
+    "lib/templates/erb/controller",
+    "lib/templates/tailwindcss/controller",
+  ].each do |templates_path|
+    test "overriding generator templates in #{templates_path}" do
+      override_dir = File.join(destination_root, templates_path)
+      FileUtils.mkdir_p override_dir
+      File.open(File.join(override_dir, "view.html.erb"), "w") { |f| f.puts "This is a custom template" }
+
+      # change directory because the generator adds a relative path to source_paths
+      Dir.chdir(destination_root) do
+        run_generator
+      end
+
+      ["index", "show"].each do |view|
+        assert_file "app/views/messages/#{view}.html.erb" do |body|
+          assert_match("This is a custom template", body, "index custom template should be used")
+        end
+      end
+    end
   end
 end
-

--- a/test/lib/generators/tailwindcss/controller_generator_test.rb
+++ b/test/lib/generators/tailwindcss/controller_generator_test.rb
@@ -3,7 +3,7 @@ require "generators/tailwindcss/controller/controller_generator"
 
 class Tailwindcss::Generators::ControllerGeneratorTest < Rails::Generators::TestCase
   tests Tailwindcss::Generators::ControllerGenerator
-  destination Dir.mktmpdir
+  destination TAILWINDCSS_TEST_APP_ROOT
 
   arguments %w(Messages index show)
 

--- a/test/lib/generators/tailwindcss/mailer_generator_test.rb
+++ b/test/lib/generators/tailwindcss/mailer_generator_test.rb
@@ -4,7 +4,7 @@ require "generators/tailwindcss/mailer/mailer_generator"
 
 class Tailwindcss::Generators::MailerGeneratorTest < Rails::Generators::TestCase
   tests Tailwindcss::Generators::MailerGenerator
-  destination Dir.mktmpdir
+  destination TAILWINDCSS_TEST_APP_ROOT
 
   arguments %w(Notifications invoice)
 

--- a/test/lib/generators/tailwindcss/mailer_generator_test.rb
+++ b/test/lib/generators/tailwindcss/mailer_generator_test.rb
@@ -51,5 +51,29 @@ class Tailwindcss::Generators::MailerGeneratorTest < Rails::Generators::TestCase
       assert_match("<%= yield %>", view)
     end
   end
-end
 
+  [
+    "lib/templates/erb/mailer",
+    "lib/templates/tailwindcss/mailer",
+  ].each do |templates_path|
+    test "overriding generator templates in #{templates_path}" do
+      override_dir = File.join(destination_root, templates_path)
+      FileUtils.mkdir_p override_dir
+      File.open(File.join(override_dir, "view.html.erb"), "w") { |f| f.puts "This is a custom template" }
+      File.open(File.join(override_dir, "layout.html.erb"), "w") { |f| f.puts "This is a custom layout" }
+
+      # change directory because the generator adds a relative path to source_paths
+      Dir.chdir(destination_root) do
+        run_generator
+      end
+
+      assert_file "app/views/notifications_mailer/invoice.html.erb" do |view|
+        assert_match("This is a custom template", view)
+      end
+
+      assert_file "app/views/layouts/mailer.html.erb" do |view|
+        assert_match("This is a custom layout", view)
+      end
+    end
+  end
+end

--- a/test/lib/generators/tailwindcss/scaffold_generator_test.rb
+++ b/test/lib/generators/tailwindcss/scaffold_generator_test.rb
@@ -3,19 +3,23 @@ require "generators/tailwindcss/scaffold/scaffold_generator"
 
 class Tailwindcss::Generators::ScaffoldGeneratorTest < Rails::Generators::TestCase
   tests Tailwindcss::Generators::ScaffoldGenerator
-  destination Dir.mktmpdir
+  destination TAILWINDCSS_TEST_APP_ROOT
 
   arguments %w(message title:string content:text)
 
-  test "generates correct view templates" do
+  test "generates view templates" do
     run_generator
 
-    %w(index edit new show _form _message).each { |view| assert_file "app/views/messages/#{view}.html.erb" }
+    %w(index edit new show _form _message).each do |view|
+      assert_file "app/views/messages/#{view}.html.erb"
+    end
   end
 
-  test "with namespace invoked" do
+  test "generates view templates with namespace" do
     run_generator [ "admin/role", "name:string", "description:string" ]
 
-    %w(index edit new show _form _role).each { |view| assert_file "app/views/admin/roles/#{view}.html.erb" }
+    %w(index edit new show _form _role).each do |view|
+      assert_file "app/views/admin/roles/#{view}.html.erb"
+    end
   end
 end

--- a/test/lib/generators/tailwindcss/scaffold_generator_test.rb
+++ b/test/lib/generators/tailwindcss/scaffold_generator_test.rb
@@ -22,4 +22,28 @@ class Tailwindcss::Generators::ScaffoldGeneratorTest < Rails::Generators::TestCa
       assert_file "app/views/admin/roles/#{view}.html.erb"
     end
   end
+
+  [
+    "lib/templates/tailwindcss/scaffold",
+    "lib/templates/erb/scaffold",
+  ].each do |templates_path|
+    test "overriding generator templates in #{templates_path}" do
+      override_dir = File.join(destination_root, templates_path)
+      FileUtils.mkdir_p override_dir
+      File.open(File.join(override_dir, "index.html.erb"), "w") { |f| f.puts "This is a custom template" }
+
+      # change directory because the generator adds a relative path to source_paths
+      Dir.chdir(destination_root) do
+        run_generator
+      end
+
+      %w(edit new show _form _message).each do |view|
+        assert_file "app/views/messages/#{view}.html.erb"
+      end
+
+      assert_file "app/views/messages/index.html.erb" do |body|
+        assert_match("This is a custom template", body, "index custom template should be used")
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,10 +4,22 @@ ENV["RAILS_ENV"] = "test"
 require "rails"
 require "rails/test_help"
 require "debug"
-require_relative "../lib/tailwindcss-rails"
 
 require "rails/test_unit/reporter"
 Rails::TestUnitReporter.executable = "bin/test"
 
+TAILWINDCSS_TEST_APP_ROOT = Dir.mktmpdir
+Rails::Generators.templates_path << File.join(TAILWINDCSS_TEST_APP_ROOT, "lib/templates")
+
 class ActiveSupport::TestCase
+  def setup
+    FileUtils.rm_rf(TAILWINDCSS_TEST_APP_ROOT)
+    FileUtils.mkdir_p(TAILWINDCSS_TEST_APP_ROOT)
+  end
+
+  def teardown
+    FileUtils.rm_rf(TAILWINDCSS_TEST_APP_ROOT)
+  end
 end
+
+require_relative "../lib/tailwindcss-rails"


### PR DESCRIPTION
Originally reported at #164

I think this PR is preferable to #247 because it has tests and is a simpler fix.

Note that in order to test this, the test suite now uses the same temporary directory for all tests, so we are then able to set `Rails::Generators.templates_path` before the generator classes are instantiated.

cc @dixpac 