### PR TITLE
Allow custom postcss.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,21 +38,6 @@ This also works with relative paths. If you've installed into your app's directo
 TAILWINDCSS_INSTALL_DIR=node_modules/.bin
 ```
 
-### Using a custom postcss.config.js
-
-If you want to use a custom `postcss.config.js`, for example to enable nesting, you can place it in the `config` folder and it will be loaded automatically.
-
-```
-module.exports = {
-  plugins: {
-    'postcss-import': {},
-    'tailwindcss/nesting': {},
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}
-```
-
 ## Developing with Tailwindcss
 
 ### Configuration
@@ -113,6 +98,24 @@ If you want unminified assets, you can pass a `debug` argument to the rake task,
 
 Note that you can combine task options, e.g. `rails tailwindcss:watch[debug,poll]`.
 
+
+### Using with PostCSS
+
+If you want to use PostCSS as a preprocessor, create a custom `config/postcss.config.js` and it will be loaded automatically.
+
+For example, to enable nesting:
+
+```js
+// config/postcss.config.js
+module.exports = {
+  plugins: {
+    'postcss-import': {},
+    'tailwindcss/nesting': {},
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}
+```
 
 ### Custom inputs or outputs
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ This also works with relative paths. If you've installed into your app's directo
 TAILWINDCSS_INSTALL_DIR=node_modules/.bin
 ```
 
+### Using a custom postcss.config.js
+
+If you want to use a custom `postcss.config.js`, for example to enable nesting, you can place it in the `config` folder and it will be loaded automatically.
+
+```
+module.exports = {
+  plugins: {
+    'postcss-import': {},
+    'tailwindcss/nesting': {},
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}
+```
 
 ## Developing with Tailwindcss
 

--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -74,15 +74,19 @@ module Tailwindcss
       end
 
       def compile_command(debug: false, **kwargs)
-        [
+        command = [
           executable(**kwargs),
           "-i", Rails.root.join("app/assets/stylesheets/application.tailwind.css").to_s,
           "-o", Rails.root.join("app/assets/builds/tailwind.css").to_s,
           "-c", Rails.root.join("config/tailwind.config.js").to_s,
-        ].tap do |command|
-          command << "--minify" unless (debug || rails_css_compressor?)
-          command << "--postcss #{Rails.root.join("config/postcss.config.js")}" if File.exist?(Rails.root.join("config/postcss.config.js"))
-        end
+        ]
+
+        command << "--minify" unless (debug || rails_css_compressor?)
+
+        postcss_path = Rails.root.join("config/postcss.config.js")
+        command += ["--postcss", postcss_path.to_s] if File.exist?(postcss_path)
+
+        command
       end
 
       def watch_command(always: false, poll: false, **kwargs)

--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -81,6 +81,7 @@ module Tailwindcss
           "-c", Rails.root.join("config/tailwind.config.js").to_s,
         ].tap do |command|
           command << "--minify" unless (debug || rails_css_compressor?)
+          command << "--postcss #{Rails.root.join("config/postcss.config.js")}" if File.exist?(Rails.root.join("config/postcss.config.js"))
         end
       end
 

--- a/test/lib/tailwindcss/commands_test.rb
+++ b/test/lib/tailwindcss/commands_test.rb
@@ -151,6 +151,27 @@ class Tailwindcss::CommandsTest < ActiveSupport::TestCase
     end
   end
 
+  test ".compile_command when postcss.config.js exists" do
+    mock_exe_directory("sparc-solaris2.8") do |dir, executable|
+      Dir.mktmpdir do |tmpdir|
+        Rails.stub(:root, Pathname.new(tmpdir))  do # Rails.root won't work in this test suite
+          actual = Tailwindcss::Commands.compile_command(exe_path: dir)
+          assert_kind_of(Array, actual)
+          assert_equal(executable, actual.first)
+          refute_includes(actual, "--postcss config/postcss.config.js")
+
+          config_file = Rails.root.join("config/postcss.config.js")
+          FileUtils.mkdir_p(Rails.root.join("config"))
+          FileUtils.touch(config_file)
+          actual = Tailwindcss::Commands.compile_command(exe_path: dir)
+          assert_kind_of(Array, actual)
+          assert_equal(executable, actual.first)
+          assert_includes(actual, "--postcss #{config_file}")
+        end
+      end
+    end
+  end
+
   test ".watch_command" do
     mock_exe_directory("sparc-solaris2.8") do |dir, executable|
       Rails.stub(:root, File) do # Rails.root won't work in this test suite

--- a/test/lib/tailwindcss/commands_test.rb
+++ b/test/lib/tailwindcss/commands_test.rb
@@ -158,7 +158,7 @@ class Tailwindcss::CommandsTest < ActiveSupport::TestCase
           actual = Tailwindcss::Commands.compile_command(exe_path: dir)
           assert_kind_of(Array, actual)
           assert_equal(executable, actual.first)
-          refute_includes(actual, "--postcss config/postcss.config.js")
+          refute_includes(actual, "--postcss")
 
           config_file = Rails.root.join("config/postcss.config.js")
           FileUtils.mkdir_p(Rails.root.join("config"))
@@ -166,7 +166,9 @@ class Tailwindcss::CommandsTest < ActiveSupport::TestCase
           actual = Tailwindcss::Commands.compile_command(exe_path: dir)
           assert_kind_of(Array, actual)
           assert_equal(executable, actual.first)
-          assert_includes(actual, "--postcss #{config_file}")
+          assert_includes(actual, "--postcss")
+          postcss_index = actual.index("--postcss")
+          assert_equal(actual[postcss_index + 1], config_file.to_s)
         end
       end
     end


### PR DESCRIPTION
Allows loading a custom `postcss.config.js` if it exists in the `config` folder.

This allows for instance enabling nesting like so:

```
module.exports = {
  plugins: {
    'postcss-import': {},
    'tailwindcss/nesting': {},
    tailwindcss: {},
    autoprefixer: {},
  },
}
```