### PR TITLE
fix finding tailwindcss

### DIFF
--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -42,7 +42,7 @@ module Tailwindcss
             MESSAGE
           end
 
-          exe_file = Dir.glob(File.expand_path(File.join(exe_path, "*", "tailwindcss"))).find do |f|
+          exe_file = Dir.glob(File.expand_path(File.join(exe_path, "**", "tailwindcss"))).find do |f|
             Gem::Platform.match_gem?(Gem::Platform.new(File.basename(File.dirname(f))), GEM_NAME)
           end
         end


### PR DESCRIPTION

```ruby
 Dir.glob(File.expand_path(File.join(exe_path, "*", "tailwindcss"))) 
# []
 
 Dir.glob(File.expand_path(File.join(exe_path, "**", "tailwindcss"))) 
 # ["/home/opc/.rbenv/versions/3.1.4/lib/ruby/gems/3.1.0/gems/tailwindcss-rails-2.3.0/exe/tailwindcss"]
 ```