### PR TITLE
Bump actions/checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "head"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: rm Gemfile.lock
       - uses: ruby/setup-ruby@v1
         with:
@@ -36,7 +36,7 @@ jobs:
   rails6:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: rm Gemfile.lock
       - uses: ruby/setup-ruby@v1
         with:
@@ -58,7 +58,7 @@ jobs:
         plat: ["ubuntu", "windows", "macos"]
     runs-on: ${{matrix.plat}}-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"

--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -22,7 +22,7 @@ jobs:
         platform: ["ruby", "x64-mingw32", "x64-mingw-ucrt", "x86_64-darwin", "x86_64-linux", "arm-linux"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: rm Gemfile.lock
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       RAILSOPTS: --git=https://github.com/rails/rails --branch main
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"


### PR DESCRIPTION
GitHub is [planning to upgrade to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). Versions prior to actions/checkout v3 use an outdated version of node, so we will upgrade to actions/checkout v4, where [Node 20 is the default](https://github.com/actions/checkout/releases/tag/v4.0.0).