### PR TITLE
Rescue from `Interrupt` in `tailwindcss:watch`

### DIFF
--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -15,6 +15,8 @@ namespace :tailwindcss do
     command = Tailwindcss::Commands.watch_command(always: always, debug: debug, poll: poll)
     puts command.inspect if args.extras.include?("verbose")
     system(*command)
+  rescue Interrupt
+    puts "Received interrupt, exiting tailwindcss:watch" if args.extras.include?("verbose")
   end
 end
 


### PR DESCRIPTION
When sending a SIGINT to end the `rake tailwindcss:watch` (or, for modern Procfile-based Rails applications, `bin/dev`) task, Ruby processes this via an `Interrupt` exception that can be rescued to handle gracefully tearing the process down. The `tailwindcss:watch` task, however, does not handle this exception, so when the task (or Rails' server via `bin/dev`) is terminated via the standard practice of using `^C`, that exception propagates and can result in a large backtrace; this can erroneously lead developers to think something is wrong.

This patch fixes #318 by rescuing `Interrupt` exceptions, which I've verified in my own applications that use this gem. It didn't seem like there's any necessary teardown that needs to happen upon quitting the process, so I left the `rescue` clause blank except for a log line when in verbose mode. I'm happy to make any necessary changes there, however! Additionally, if that `rescue` should occur elsewhere, like directly in `exe/tailwindcss`, I'm happy to do so there as well. I wasn't sure if that's where it belonged, however, as the other commands aren't meant to run indefinitely until killed.