### PR TITLE
fixing clobber task

### DIFF
--- a/lib/tasks/clobber.rake
+++ b/lib/tasks/clobber.rake
@@ -1,7 +1,7 @@
 namespace :tailwindcss do
   desc "Remove CSS builds"
   task :clobber do
-    rm_rf Dir["app/assets/builds/[^.]*.css"], verbose: false
+    FileUtils.rm_rf Dir["app/assets/builds/[^.]*.css"], verbose: false
   end
 end
 


### PR DESCRIPTION
When running rails tailwindcss:clobber you get the following exception:

```
rails aborted!
ArgumentError: wrong number of arguments (given 2, expected 1)
/usr/local/lib/ruby/3.2.0/fileutils.rb:1346:in `rm_rf'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/file_utils_ext.rb:35:in `rm_rf'
/usr/local/bundle/gems/tailwindcss-rails-2.3.0-x86_64-linux/lib/tasks/clobber.rake:5:in `block (2 levels) in <top (required)>'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/task.rb:273:in `block in execute'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/task.rb:273:in `each'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/task.rb:273:in `execute'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/task.rb:214:in `block in invoke_with_call_chain'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/task.rb:194:in `synchronize'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/task.rb:194:in `invoke_with_call_chain'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/task.rb:238:in `block in invoke_prerequisites'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/task.rb:236:in `each'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/task.rb:236:in `invoke_prerequisites'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/task.rb:213:in `block in invoke_with_call_chain'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/task.rb:194:in `synchronize'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/task.rb:194:in `invoke_with_call_chain'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/task.rb:183:in `invoke'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/application.rb:160:in `invoke_task'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/application.rb:116:in `block (2 levels) in top_level'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/application.rb:116:in `each'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/application.rb:116:in `block in top_level'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/application.rb:125:in `run_with_threads'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/application.rb:110:in `top_level'
/usr/local/bundle/gems/railties-7.0.4.3/lib/rails/commands/rake/rake_command.rb:24:in `block (2 levels) in perform'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/application.rb:186:in `standard_exception_handling'
/usr/local/bundle/gems/railties-7.0.4.3/lib/rails/commands/rake/rake_command.rb:24:in `block in perform'
/usr/local/bundle/gems/rake-12.3.3/lib/rake/rake_module.rb:59:in `with_application'
/usr/local/bundle/gems/railties-7.0.4.3/lib/rails/commands/rake/rake_command.rb:18:in `perform'
/usr/local/bundle/gems/railties-7.0.4.3/lib/rails/command.rb:51:in `invoke'
/usr/local/bundle/gems/railties-7.0.4.3/lib/rails/commands.rb:18:in `<top (required)>'
```

When calling rm_rf using FileUtils everything works fine