### PR TITLE
ci: add arm64-darwin coverage on macos-14

### DIFF
--- a/.github/workflows/gem-install.yml
+++ b/.github/workflows/gem-install.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ["ruby", "x64-mingw32", "x64-mingw-ucrt", "x86_64-darwin", "x86_64-linux", "arm-linux"]
+        platform: ["ruby", "x64-mingw32", "x64-mingw-ucrt", "x86_64-darwin", "arm64-darwin", "x86_64-linux", "arm-linux"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -96,9 +96,9 @@ jobs:
               tailwindcss --help
             "
 
-  darwin-install:
+  darwin-x86_64-install:
     needs: ["package"]
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: ruby/setup-ruby@v1
         with:
@@ -106,6 +106,20 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: gem-x86_64-darwin
+          path: pkg
+      - run: "gem install pkg/tailwindcss-rails-*.gem"
+      - run: "tailwindcss --help"
+
+  darwin-arm64-install:
+    needs: ["package"]
+    runs-on: macos-14
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+      - uses: actions/download-artifact@v3
+        with:
+          name: gem-arm64-darwin
           path: pkg
       - run: "gem install pkg/tailwindcss-rails-*.gem"
       - run: "tailwindcss --help"


### PR DESCRIPTION
and pin x86_64-darwin to macos-13

See flavorjones/ruby-c-extensions-explained#30 for context