### PR TITLE
generator: drop the tailwind aspect-ratio plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## next / unreleased
+
+* Remove the `@tailwindcss/aspect-ratio` plugin from the `tailwind.config.js` that gets installed by the generator. (#344) @flavorjones @searls
+
+
 ## v2.4.1 / 2024-04-25
 
 * Fix debugger repl when using the Puma plugin. (#349) @tompng

--- a/lib/install/tailwind.config.js
+++ b/lib/install/tailwind.config.js
@@ -16,7 +16,6 @@ module.exports = {
   },
   plugins: [
     require('@tailwindcss/forms'),
-    require('@tailwindcss/aspect-ratio'),
     require('@tailwindcss/typography'),
     require('@tailwindcss/container-queries'),
   ]


### PR DESCRIPTION
This plugin was originally a polyfill to handle the time gap until Safari 15 was released (in Fall 2021), and so is beyond its useful lifetime for anyone not targetting ancient browsers.

Closes #344

cc @searls 