### PR TITLE
Increase form input field border contrast

### DIFF
--- a/lib/generators/tailwindcss/scaffold/templates/_form.html.erb.tt
+++ b/lib/generators/tailwindcss/scaffold/templates/_form.html.erb.tt
@@ -15,23 +15,23 @@
   <div class="my-5">
 <% if attribute.password_digest? -%>
     <%%= form.label :password %>
-    <%%= form.password_field :password, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%%= form.password_field :password, class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>
 </div>
 
 <div class="my-5">
     <%%= form.label :password_confirmation %>
-    <%%= form.password_field :password_confirmation, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%%= form.password_field :password_confirmation, class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>
 <% elsif attribute.attachments? -%>
     <%%= form.label :<%= attribute.column_name %> %>
-    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, multiple: true, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, multiple: true, class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>
 <% else -%>
     <%%= form.label :<%= attribute.column_name %> %>
 <% if attribute.field_type == :text_area -%>
-    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, rows: 4, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, rows: 4, class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>
 <% elsif attribute.field_type == :check_box -%>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, class: "block mt-2 h-5 w-5" %>
 <% else -%>
-    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>
 <% end -%>
 <% end -%>
   </div>


### PR DESCRIPTION
The contrast provided by the `border-gray-200` Tailwind utility class is very poor. It's nearly impossible to distinguish the edges  of an input field on a white background. 

That's not a great default experience for Rails scaffolds.

With a slight bump to `border-gray-400`, things are much easier  to distinguish.

Here's a simple example where I only changed the border class on the `Name` field at the top: 

Safari:
<img width="1102" alt="image" src="https://github.com/rails/tailwindcss-rails/assets/65950/9492b400-7209-41fe-a279-6aefef65ee6e">

Firefox: 
<img width="1122" alt="image" src="https://github.com/rails/tailwindcss-rails/assets/65950/6485c7c8-3c77-41fa-8865-d7dd17711a51">

Chrome: 
<img width="1123" alt="image" src="https://github.com/rails/tailwindcss-rails/assets/65950/6c354836-826b-4757-ad59-52182fa83e47">

With a stock Rails 7.1 app, I genuinely could not distinguish the edges of any input field until I made this change. I think the examples speak for themselves. I can understand the desire for subtlety but I think this change would be beneficial. I'm deliberately not address a similar issue with non-call-to-action buttons in this PR, in case there's disagreement. 