### PR TITLE
Force bin/dev overwrite to deal with new default bin/dev file

### DIFF
--- a/lib/install/tailwindcss.rb
+++ b/lib/install/tailwindcss.rb
@@ -49,7 +49,7 @@ else
 end
 
 say "Add bin/dev to start foreman"
-copy_file "#{__dir__}/dev", "bin/dev"
+copy_file "#{__dir__}/dev", "bin/dev", force: true
 chmod "bin/dev", 0755, verbose: false
 
 say "Compile initial Tailwind build"


### PR DESCRIPTION
Ref: https://github.com/rails/rails/pull/52433.

Fixes `rails new myapp --main --css tailwind` currently blocking, waiting for user input:

```
  Add bin/dev to start foreman
    conflict    bin/dev
  Overwrite /Users/jerome/c/rails/myapp/bin/dev? (enter "h" for help) [Ynaqdhm]
```

After merging this PR, it would be nice if a new release could be cut, so `rails new myapp --main --css tailwind` doesn't block.