### PR TITLE
Disable loading .env file when running foreman for development

### DIFF
--- a/lib/install/dev
+++ b/lib/install/dev
@@ -13,4 +13,4 @@ export PORT="${PORT:-3000}"
 export RUBY_DEBUG_OPEN="true"
 export RUBY_DEBUG_LAZY="true"
 
-exec foreman start -f Procfile.dev "$@"
+exec foreman start -f Procfile.dev --env /dev/null "$@"


### PR DESCRIPTION
Same as in rails/cssbundling-rails#155 and rails/jsbundling-rails@0ff85a2255b732556ee30d28634ecdb15a50d0ae

We should just not load the .env when running foreman locally for bundling etc.