### PR TITLE
dep: bump tailwindcss to v3.4.9

### DIFF
--- a/lib/tailwindcss/upstream.rb
+++ b/lib/tailwindcss/upstream.rb
@@ -1,7 +1,7 @@
 module Tailwindcss
   # constants describing the upstream tailwindcss project
   module Upstream
-    VERSION = "v3.4.8"
+    VERSION = "v3.4.9"
 
     # rubygems platform name => upstream release filename
     NATIVE_PLATFORMS = {


### PR DESCRIPTION
https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.4.9