### PR TITLE
Make copies of the auth templates for Rails 8 beta1

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -10,8 +10,6 @@ on:
     types: [opened, synchronize]
     branches:
       - '*'
-    paths:
-      - .github/workflows/upstream.yml # this file
 
 jobs:
   tests:
@@ -37,14 +35,15 @@ jobs:
         run: bin/test
 
   user-journey:
-    name: "user-journey (rails main)"
+    name: "user-journey (rails ${{ matrix.ref }})"
     runs-on: ${{matrix.plat}}-latest
     strategy:
       fail-fast: false
       matrix:
-        plat: ["ubuntu", "windows", "macos"]
+        plat: ["ubuntu"]
+        ref: ["7-2-stable", "v8.0.0.beta1", "main"]
     env:
-      RAILSOPTS: --git=https://github.com/rails/rails --branch main
+      RAILSOPTS: --git=https://github.com/rails/rails --ref=${{ matrix.ref }}
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/lib/generators/tailwindcss/authentication/templates/views/passwords/edit.html.erb
+++ b/lib/generators/tailwindcss/authentication/templates/views/passwords/edit.html.erb
@@ -1,0 +1,21 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <%% if alert = flash[:alert] %>
+    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%%= alert %></p>
+  <%% end %>
+
+  <h1 class="font-bold text-4xl">Update your password</h1>
+
+  <%%= form_with url: password_path(params[:token]), method: :put, class: "contents" do |form| %>
+    <div class="my-5">
+      <%%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: "Enter new password", maxlength: 72, class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>
+    </div>
+
+    <div class="my-5">
+      <%%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Repeat new password", maxlength: 72, class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>
+    </div>
+
+    <div class="inline">
+      <%%= form.submit "Save", class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+    </div>
+  <%% end %>
+</div>

--- a/lib/generators/tailwindcss/authentication/templates/views/passwords/new.html.erb
+++ b/lib/generators/tailwindcss/authentication/templates/views/passwords/new.html.erb
@@ -1,0 +1,17 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <%% if alert = flash[:alert] %>
+    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%%= alert %></p>
+  <%% end %>
+
+  <h1 class="font-bold text-4xl">Forgot your password?</h1>
+
+  <%%= form_with url: passwords_path, class: "contents" do |form| %>
+    <div class="my-5">
+      <%%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>
+    </div>
+
+    <div class="inline">
+      <%%= form.submit "Email reset instructions", class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+    </div>
+  <%% end %>
+</div>

--- a/lib/generators/tailwindcss/authentication/templates/views/sessions/new.html.erb
+++ b/lib/generators/tailwindcss/authentication/templates/views/sessions/new.html.erb
@@ -1,0 +1,31 @@
+<div class="mx-auto md:w-2/3 w-full">
+  <%% if alert = flash[:alert] %>
+    <p class="py-2 px-3 bg-red-50 mb-5 text-red-500 font-medium rounded-lg inline-block" id="alert"><%%= alert %></p>
+  <%% end %>
+
+  <%% if notice = flash[:notice] %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%%= notice %></p>
+  <%% end %>
+
+  <h1 class="font-bold text-4xl">Sign in</h1>
+
+  <%%= form_with url: session_url, class: "contents" do |form| %>
+    <div class="my-5">
+      <%%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>
+    </div>
+
+    <div class="my-5">
+      <%%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: "Enter your password", maxlength: 72, class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>
+    </div>
+
+    <div class="col-span-6 sm:flex sm:items-center sm:gap-4">
+      <div class="inline">
+        <%%= form.submit "Sign in", class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>
+      </div>
+
+      <div class="mt-4 text-sm text-gray-500 sm:mt-0">
+        <%%= link_to "Forgot password?", new_password_path, class: "text-gray-700 underline" %>
+      </div>
+    </div>
+  <%% end %>
+</div>

--- a/test/integration/user_journey_test.sh
+++ b/test/integration/user_journey_test.sh
@@ -32,12 +32,13 @@ bundle add rails --skip-install ${RAILSOPTS:-}
 bundle add tailwindcss-rails --path="../.."
 bundle install
 bundle show --paths
+bundle binstubs --all
 
 # install tailwindcss
 bin/rails tailwindcss:install
 
 # TEST: tailwind was installed correctly
-grep tailwind app/views/layouts/application.html.erb
+grep -q tailwind app/views/layouts/application.html.erb
 
 # TEST: rake tasks don't exec (#188)
 cat <<EOF >> Rakefile
@@ -47,3 +48,13 @@ end
 EOF
 
 bin/rails tailwindcss:build still_here | grep "Rake process did not exit early"
+
+if [[ $(rails -v) > "Rails 8.0.0.beta" ]] ; then
+  # TEST: presence of the generated file
+  bin/rails generate authentication
+  grep -q PasswordsController app/controllers/passwords_controller.rb
+fi
+
+# TEST: presence of the generated file
+bin/rails generate scaffold post title:string body:text published:boolean
+grep -q "Show this post" app/views/posts/index.html.erb


### PR DESCRIPTION
And add test coverage for the generator templates.

We can revert the "copy templates" commit once beta2 is out.

See https://github.com/rails/tailwindcss-rails/pull/407 for context.