### PR TITLE
Prevent duplicate tailwind css reference

### DIFF
--- a/lib/install/tailwindcss.rb
+++ b/lib/install/tailwindcss.rb
@@ -4,7 +4,7 @@ CENTERING_CONTAINER_INSERTION_POINT = /^\s*<%= yield %>/.freeze
 if APPLICATION_LAYOUT_PATH.exist?
   say "Add Tailwindcss include tags and container element in application layout"
   insert_into_file APPLICATION_LAYOUT_PATH.to_s, <<~ERB.indent(4), before: /^\s*<%= stylesheet_link_tag/
-    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "inter-font", "data-turbo-track": "reload" %>
   ERB
 
   if File.open(APPLICATION_LAYOUT_PATH).read =~ /<body>\n\s*<%= yield %>\n\s*<\/body>/


### PR DESCRIPTION
On a newly generated 8.0.0.beta1 app it seems that the tailwind.css is referenced twice with the head of the generated layout

```
<link rel="stylesheet" href="/assets/tailwind-aaa98186.css" data-turbo-track="reload" />
<link rel="stylesheet" href="/assets/inter-font-1d90a608.css" data-turbo-track="reload" />
<link rel="stylesheet" href="/assets/application-8b441ae0.css" data-turbo-track="reload" />
<link rel="stylesheet" href="/assets/application.tailwind-bb2039bf.css" data-turbo-track="reload" />
<link rel="stylesheet" href="/assets/tailwind-aaa98186.css" data-turbo-track="reload" />
```

it seems that the injected stylesheet_link_tag is including the tailwind stylesheet 
```
<%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
```

it is automatically included from the 'app' stylesheet call from the app/build directory

`<%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>`

removing the tailwind reference 
```
<%= stylesheet_link_tag "inter-font", "data-turbo-track": "reload" %>
```

prevents the duplicate in the generated layout

```
<link rel="stylesheet" href="/assets/inter-font-1d90a608.css" data-turbo-track="reload" />
<link rel="stylesheet" href="/assets/application-8b441ae0.css" data-turbo-track="reload" />
<link rel="stylesheet" href="/assets/application.tailwind-bb2039bf.css" data-turbo-track="reload" />
<link rel="stylesheet" href="/assets/tailwind-aaa98186.css" data-turbo-track="reload" />
```