### PR TITLE
Handle both rails 7.2 and rails 8.0 field types for checkbox/textarea

### DIFF
--- a/lib/generators/tailwindcss/scaffold/templates/_form.html.erb.tt
+++ b/lib/generators/tailwindcss/scaffold/templates/_form.html.erb.tt
@@ -26,9 +26,9 @@
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, multiple: true, class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>
 <% else -%>
     <%%= form.label :<%= attribute.column_name %> %>
-<% if attribute.field_type == :text_area -%>
+<% if attribute.field_type == :textarea || attribute.field_type == :text_area -%>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, rows: 4, class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>
-<% elsif attribute.field_type == :checkbox -%>
+<% elsif attribute.field_type == :checkbox || attribute.field_type == :check_box -%>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, class: "block mt-2 h-5 w-5" %>
 <% else -%>
     <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, class: "block shadow rounded-md border border-gray-400 outline-none px-3 py-2 mt-2 w-full" %>


### PR DESCRIPTION
Followup to https://github.com/rails/tailwindcss-rails/pull/416

They got renamed (with aliases being present) in:
* https://github.com/rails/rails/pull/52432
* https://github.com/rails/rails/pull/52467

This ensures the correct classes are generated for both old and new versions. I added a test locally but it can only assert against the exact css classes since there is nothing else to properly distinquish them. I can add this here if you wish, just didn't seem like the best test.

@enderahmetyurt, I suspect you generated your sample app with rails 8.0.0.beta1 which is why it looked weird for you.