### PR TITLE
Add failing spec for Tailwind v4

### DIFF
--- a/test/integration/user_journey_test.sh
+++ b/test/integration/user_journey_test.sh
@@ -61,4 +61,11 @@ grep -q "Show this post" app/views/posts/index.html.erb
 bin/rails tailwindcss:build[verbose]
 grep -q "py-2" app/assets/builds/tailwind.css
 
+# TEST: edit the css file by adding a custom property to the @theme block 
+tailwind_application_css_file_path="app/assets/stylesheets/application.tailwind.css"
+echo -e "\n@theme { --color-tomato: #fafafa; }" >> "$tailwind_application_css_file_path"
+
+bin/rails tailwindcss:build[verbose]
+grep -q "fafafa" app/assets/builds/tailwind.css
+
 echo "OK"


### PR DESCRIPTION
This PR adds a failing assertion to the integration test. The new test:
- Adds a `@theme` block 
- inserts a custom property
- runs the build command
- asserts that the custom property is in the output file.

I'm completely new to the codebase so there's probably a lot that's missing here but I wanted to start the conversation with a failing spec to get things going.