### PR TITLE
make the index a table again

### DIFF
--- a/lib/generators/tailwindcss/scaffold/templates/index.html.erb.tt
+++ b/lib/generators/tailwindcss/scaffold/templates/index.html.erb.tt
@@ -2,11 +2,11 @@
 
 <div class="w-full">
   <%% if notice.present? %>
-    <p class="inline-block px-3 py-2 mb-5 font-medium text-green-500 rounded-md bg-green-50" id="notice"><%%= notice %></p>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%%= notice %></p>
   <%% end %>
 
-  <div class="flex items-center justify-between">
-    <h1 class="text-4xl font-bold"><%= human_name.pluralize %></h1>
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-4xl"><%= human_name.pluralize %></h1>
     <%%= link_to "New <%= human_name.downcase %>", new_<%= singular_route_name %>_path, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white block font-medium" %>
   </div>
 
@@ -22,20 +22,34 @@
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200">
-          <%% @users.each do |user| %>
+          <%% @<%= plural_table_name %>.each do |<%= singular_name %>| %>
             <tr class="border-b">
 <% attributes.reject(&:password_digest?).each do |attribute| -%>
+<% if attribute.attachment? -%>
+              <td class="py-4 whitespace-nowrap"><%%= link_to <%= singular_name %>.<%= attribute.column_name %>.filename, <%= singular_name %>.<%= attribute.column_name %> if <%= singular_name %>.<%= attribute.column_name %>.attached? %></td>
+<% elsif attribute.attachments? -%>
+              <td class="py-4 whitespace-nowrap">
+                <%% <%= singular_name %>.<%= attribute.column_name %>.each do |<%= attribute.singular_name %>| %>
+                  <div><%%= link_to <%= attribute.singular_name %>.filename, <%= attribute.singular_name %> %></div>
+                <%% end %>
+              </td>
+<% else -%>
               <td class="py-4 whitespace-nowrap"><%%= <%= singular_name %>.<%= attribute.column_name %> %></td>
+<% end -%>
 <% end -%>
               <td class="py-4 space-x-4 whitespace-nowrap">
                 <%%= link_to "Show", <%= model_resource_name(singular_table_name) %>, class: "text-blue-600 hover:text-blue-900" %>
+                <%%= link_to "Edit", edit_<%= singular_route_name %>_path(<%= singular_table_name %>), class: "text-blue-600 hover:text-blue-900" %>
+                <div class="inline-block ml-2">
+                  <%%= button_to "Destroy", <%= model_resource_name %>, method: :delete, class: "text-red-600 hover:text-red-900" %>
+                </div>
               </td>
             </tr>
           <%% end %>
         </tbody>
       </table>
     <%% else %>
-      <p class="my-10 text-center">No <%= human_name.downcase.pluralize %> found.</p>
+      <p class="text-center my-10">No <%= human_name.downcase.pluralize %> found.</p>
     <%% end %>
   </div>
 </div>

--- a/lib/generators/tailwindcss/scaffold/templates/index.html.erb.tt
+++ b/lib/generators/tailwindcss/scaffold/templates/index.html.erb.tt
@@ -2,24 +2,40 @@
 
 <div class="w-full">
   <%% if notice.present? %>
-    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%%= notice %></p>
+    <p class="inline-block px-3 py-2 mb-5 font-medium text-green-500 rounded-md bg-green-50" id="notice"><%%= notice %></p>
   <%% end %>
 
-  <div class="flex justify-between items-center">
-    <h1 class="font-bold text-4xl"><%= human_name.pluralize %></h1>
+  <div class="flex items-center justify-between">
+    <h1 class="text-4xl font-bold"><%= human_name.pluralize %></h1>
     <%%= link_to "New <%= human_name.downcase %>", new_<%= singular_route_name %>_path, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white block font-medium" %>
   </div>
 
-  <div id="<%= plural_table_name %>" class="min-w-full">
+  <div id="<%= plural_table_name %>" class="inline-block min-w-full mt-10">
     <%% if @<%= plural_table_name %>.any? %>
-      <%% @<%= plural_table_name %>.each do |<%= singular_table_name %>| %>
-        <%%= render <%= singular_table_name %> %>
-        <p>
-          <%%= link_to "Show this <%= human_name.downcase %>", <%= model_resource_name(singular_table_name) %>, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-        </p>
-      <%% end %>
+      <table class="min-w-full divide-y divide-gray-300">
+        <thead>
+          <tr>
+<% attributes.reject(&:password_digest?).each do |attribute| -%>
+            <th class="py-3.5 text-left font-semibold"><%= attribute.human_name %></th>
+<% end -%>
+            <th class="py-3.5 text-left font-semibold">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+          <%% @users.each do |user| %>
+            <tr class="border-b">
+<% attributes.reject(&:password_digest?).each do |attribute| -%>
+              <td class="py-4 whitespace-nowrap"><%%= <%= singular_name %>.<%= attribute.column_name %> %></td>
+<% end -%>
+              <td class="py-4 space-x-4 whitespace-nowrap">
+                <%%= link_to "Show", <%= model_resource_name(singular_table_name) %>, class: "text-blue-600 hover:text-blue-900" %>
+              </td>
+            </tr>
+          <%% end %>
+        </tbody>
+      </table>
     <%% else %>
-      <p class="text-center my-10">No <%= human_name.downcase.pluralize %> found.</p>
+      <p class="my-10 text-center">No <%= human_name.downcase.pluralize %> found.</p>
     <%% end %>
   </div>
 </div>

--- a/test/integration/user_journey_test.sh
+++ b/test/integration/user_journey_test.sh
@@ -68,7 +68,7 @@ fi
 
 # TEST: presence of the generated file
 bin/rails generate scaffold post title:string body:text published:boolean
-grep -q "Show this post" app/views/posts/index.html.erb
+grep -q "Show" app/views/posts/index.html.erb
 
 # TEST: contents of the css file
 bin/rails tailwindcss:build[verbose]


### PR DESCRIPTION
As per [this PR](https://github.com/rails/rails/pull/41210), the scaffold generator stopped generating a table in the index page, and encourages css frameworks gems (such as this) to do the styling. 

I don't quite like what the generator generates currently (design wise, although I'm no designer), so I thought of bringing back the table, with a basic style so it's ready to use (or as ready to use as possible).

I looked for box-style CRUD designs so we could keep using the partial but I couldn't find anything.

As always, before and after pictures:

| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/4aaa6447-5ce6-469d-8a92-0dca8d425173) | ![image](https://github.com/user-attachments/assets/c329a138-a15d-4163-b493-45102d84f073) |