### PR TITLE
improve partial: correct use of tags + attachment links styling

### DIFF
--- a/lib/generators/tailwindcss/scaffold/templates/partial.html.erb.tt
+++ b/lib/generators/tailwindcss/scaffold/templates/partial.html.erb.tt
@@ -1,16 +1,16 @@
-<div id="<%%= dom_id <%= singular_name %> %>">
+<div id="<%%= dom_id <%= singular_name %> %>" class="my-5 space-y-5">
 <% attributes.reject(&:password_digest?).each do |attribute| -%>
-  <p class="my-5">
+  <div>
     <strong class="block font-medium mb-1"><%= attribute.human_name %>:</strong>
 <% if attribute.attachment? -%>
-    <%%= link_to <%= singular_name %>.<%= attribute.column_name %>.filename, <%= singular_name %>.<%= attribute.column_name %> if <%= singular_name %>.<%= attribute.column_name %>.attached? %>
+    <%%= link_to <%= singular_name %>.<%= attribute.column_name %>.filename, <%= singular_name %>.<%= attribute.column_name %>, class: "text-gray-700 underline hover:no-underline" if <%= singular_name %>.<%= attribute.column_name %>.attached? %>
 <% elsif attribute.attachments? -%>
     <%% <%= singular_name %>.<%= attribute.column_name %>.each do |<%= attribute.singular_name %>| %>
-      <div><%%= link_to <%= attribute.singular_name %>.filename, <%= attribute.singular_name %> %></div>
+      <div><%%= link_to <%= attribute.singular_name %>.filename, <%= attribute.singular_name %>, class: "text-gray-700 underline hover:no-underline" %></div>
     <%% end %>
 <% else -%>
     <%%= <%= singular_name %>.<%= attribute.column_name %> %>
 <% end -%>
-  </p>
+  </div>
 <% end -%>
 </div>


### PR DESCRIPTION
The partial used `<p>` elements for each attribute, which auto-close if it contains a `<div>` element (see [the technical summary of the p tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p#technical_summary)). To avoid this, I'm changing the `p` elements to `div` elements.

Also, adding some basic styling for the attachment links.

See before and after screenshots:

| before | after | comment |
| --- | --- | --- |
| ![image](https://github.com/user-attachments/assets/a64521c5-ab98-4829-95c2-d8ea3ea0d5e9) | ![image](https://github.com/user-attachments/assets/de6a6a2a-363e-4c7a-a11c-eca27966a8b8) | the space between "Documents" and the links changed due to the correct use of tags, and the links now are styled differently (similar to "forgot your password?" link |
| ![image](https://github.com/user-attachments/assets/94d9cb6d-e7c0-4a5d-a0b9-7bf3630ed003) | ![image](https://github.com/user-attachments/assets/2c9722f5-f095-497b-9c88-35a92b79ef4f) | the p element auto-closed due to the inner div, by changing it to a div we produce a better output |