### PR TITLE
index: show the actions to the right of the partial and add a division

### DIFF
--- a/lib/generators/tailwindcss/scaffold/templates/index.html.erb.tt
+++ b/lib/generators/tailwindcss/scaffold/templates/index.html.erb.tt
@@ -10,13 +10,19 @@
     <%%= link_to "New <%= human_name.downcase %>", new_<%= singular_route_name %>_path, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white block font-medium" %>
   </div>
 
-  <div id="<%= plural_table_name %>" class="min-w-full">
+  <div id="<%= plural_table_name %>" class="min-w-full divide-y divide-gray-200 space-y-5">
     <%% if @<%= plural_table_name %>.any? %>
       <%% @<%= plural_table_name %>.each do |<%= singular_table_name %>| %>
-        <%%= render <%= singular_table_name %> %>
-        <p>
-          <%%= link_to "Show this <%= human_name.downcase %>", <%= model_resource_name(singular_table_name) %>, class: "ml-2 rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-        </p>
+        <div class="flex justify-between items-center">
+          <%%= render <%= singular_table_name %> %>
+          <div class="space-x-2">
+            <%%= link_to "Show", <%= model_resource_name(singular_table_name) %>, class: "rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+            <%%= link_to "Edit", edit_<%= singular_route_name %>_path(<%= singular_table_name %>), class: "rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+            <div class="inline-block">
+              <%%= button_to "Destroy", <%= model_resource_name %>, method: :delete, class: "rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium" %>
+            </div>
+          </div>
+        </div>
       <%% end %>
     <%% else %>
       <p class="text-center my-10">No <%= human_name.downcase.pluralize %> found.</p>

--- a/lib/generators/tailwindcss/scaffold/templates/index.html.erb.tt
+++ b/lib/generators/tailwindcss/scaffold/templates/index.html.erb.tt
@@ -17,7 +17,7 @@
           <%%= render <%= singular_table_name %> %>
           <div class="space-x-2">
             <%%= link_to "Show", <%= model_resource_name(singular_table_name) %>, class: "rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
-            <%%= link_to "Edit", edit_<%= singular_route_name %>_path(<%= singular_table_name %>), class: "rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+            <%%= link_to "Edit", <%= edit_helper(singular_table_name, type: :path) %>, class: "rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
             <div class="inline-block">
               <%%= button_to "Destroy", <%= model_resource_name %>, method: :delete, class: "rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium" %>
             </div>

--- a/test/integration/user_install_test.sh
+++ b/test/integration/user_install_test.sh
@@ -61,7 +61,7 @@ fi
 
 # TEST: presence of the generated file
 bin/rails generate scaffold post title:string body:text published:boolean
-grep -q "Show this post" app/views/posts/index.html.erb
+grep -q "Show" app/views/posts/index.html.erb
 
 # TEST: contents of the css file
 bin/rails tailwindcss:build[verbose]


### PR DESCRIPTION
between objects.

Currently, when your collection has many objects, and given the "show this xxx" button is grey, it's hard to distinguish when an object ends and another one begins. 

This PR adds a subtle division between objects and wraps the partial in a flex item, moving the show button to the right hand side. Also, as suggested in #457 , I've added the edit and destroy buttons.

| before | after |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/024de0b2-72c9-4379-ba93-e812d9f63ab4) | ![image](https://github.com/user-attachments/assets/e10a908f-e001-4179-b0ac-495321d88bd8) |