### PR TITLE
dep: pin tailwindcss-ruby to `~> 3.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         plat: ["ubuntu", "windows", "macos"]
-        tailwind: ["--version=~>3.4.14", "--version=~>4.0.0.alpha.27"]
+        tailwind: ["--version=~>3.4.14"]
     runs-on: ${{matrix.plat}}-latest
     env:
       TAILWINDCSSOPTS: ${{ matrix.tailwind }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - v*-stable
     tags:
       - v*.*.*
   pull_request:

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         plat: ["ubuntu"]
         ref: ["7-2-stable", "8-0-stable", "main"]
-        tailwind: ["--version=~>3.4.14", "--version=~>4.0.0.alpha.27"]
+        tailwind: ["--version=~>3.4.14"]
     env:
       RAILSOPTS: --git=https://github.com/rails/rails --ref=${{ matrix.ref }}
       TAILWINDCSSOPTS: ${{ matrix.tailwind }}

--- a/tailwindcss-rails.gemspec
+++ b/tailwindcss-rails.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "railties", ">= 7.0.0"
-  spec.add_dependency "tailwindcss-ruby"
+  spec.add_dependency "tailwindcss-ruby", "~> 3.0"
 end


### PR DESCRIPTION
Now that we've done the work to be compatible with Tailwind v4 in a v4.0.0.rc1, I think we know enough to recommend against using Tailwind v4 with tailwindcss-rails v3.

Let's prevent unintentional upgrades and problems for users. This will go into a (final?) v3 release.