### PR TITLE
fix: unnecessary stylesheet_link_tag for tailwind

### DIFF
--- a/lib/install/install_tailwindcss.rb
+++ b/lib/install/install_tailwindcss.rb
@@ -2,11 +2,14 @@ APPLICATION_LAYOUT_PATH             = Rails.root.join("app/views/layouts/applica
 CENTERING_CONTAINER_INSERTION_POINT = /^\s*<%= yield %>/.freeze
 
 if APPLICATION_LAYOUT_PATH.exist?
-  say "Add Tailwindcss include tags and container element in application layout"
-  insert_into_file APPLICATION_LAYOUT_PATH.to_s, <<~ERB.indent(4), before: /^\s*<%= stylesheet_link_tag/
-    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
-  ERB
+  unless File.read(APPLICATION_LAYOUT_PATH).match?(/stylesheet_link_tag :app/)
+    say "Add Tailwindcss include tags in application layout"
+    insert_into_file APPLICATION_LAYOUT_PATH.to_s, <<~ERB.indent(4), before: /^\s*<%= stylesheet_link_tag/
+      <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    ERB
+  end
 
+  say "Add Tailwindcss container element in application layout"
   if File.open(APPLICATION_LAYOUT_PATH).read =~ /<body>\n\s*<%= yield %>\n\s*<\/body>/
     insert_into_file APPLICATION_LAYOUT_PATH.to_s, %(    <main class="container mx-auto mt-28 px-5 flex">\n  ), before: CENTERING_CONTAINER_INSERTION_POINT
     insert_into_file APPLICATION_LAYOUT_PATH.to_s, %(\n    </main>),  after: CENTERING_CONTAINER_INSERTION_POINT

--- a/lib/install/upgrade_tailwindcss.rb
+++ b/lib/install/upgrade_tailwindcss.rb
@@ -18,6 +18,12 @@ if POSTCSS_CONFIG_PATH.exist?
 end
 
 if APPLICATION_LAYOUT_PATH.exist?
+  if File.read(APPLICATION_LAYOUT_PATH).match?(/stylesheet_link_tag :app/) &&
+     File.read(APPLICATION_LAYOUT_PATH).match?(/stylesheet_link_tag "tailwind"/)
+    say "Remove unnecessary stylesheet_link_tag from application layout"
+    gsub_file APPLICATION_LAYOUT_PATH.to_s, %r{^\s*<%= stylesheet_link_tag "tailwind".*%>$}, ""
+  end
+
   if File.read(APPLICATION_LAYOUT_PATH).match?(/"inter-font"/)
     say "Strip Inter font CSS from application layout"
     gsub_file APPLICATION_LAYOUT_PATH.to_s, %r{, "inter-font"}, ""

--- a/test/integration/user_install_test.sh
+++ b/test/integration/user_install_test.sh
@@ -36,7 +36,8 @@ bundle binstubs --all
 bin/rails tailwindcss:install
 
 # TEST: tailwind was installed correctly
-grep -q tailwind app/views/layouts/application.html.erb
+grep -q "<main class=\"container" app/views/layouts/application.html.erb
+test -a app/assets/stylesheets/application.tailwind.css
 
 # TEST: rake tasks don't exec (#188)
 cat <<EOF >> Rakefile


### PR DESCRIPTION
In Rails 8, propshaft detects `:app` and loads all the css files under app/assets/stylesheets, so we may not need this explicit tag for tailwind.

On installation, omit the tailwind stylesheet link tag if `:app` is already being passed to stylesheet_link_tag in the layout.

On upgrade, remove the tailwind stylesheet link tag if `:app` is already being passed to stylesheet_link_tag in the layout.

See related discussion at https://github.com/rails/tailwindcss-rails/pull/412