### PR TITLE
Move application.tailwind.css to a dir ignored by propshaft

### DIFF
--- a/lib/install/install_tailwindcss.rb
+++ b/lib/install/install_tailwindcss.rb
@@ -1,5 +1,6 @@
 APPLICATION_LAYOUT_PATH             = Rails.root.join("app/views/layouts/application.html.erb")
 CENTERING_CONTAINER_INSERTION_POINT = /^\s*<%= yield %>/.freeze
+TAILWIND_ASSET_PATH                 = Rails.root.join("app/assets/tailwind")
 
 if APPLICATION_LAYOUT_PATH.exist?
   unless File.read(APPLICATION_LAYOUT_PATH).match?(/stylesheet_link_tag :app/)
@@ -31,9 +32,9 @@ if Rails.root.join(".gitignore").exist?
   append_to_file(".gitignore", %(\n/app/assets/builds/*\n!/app/assets/builds/.keep\n))
 end
 
-unless Rails.root.join("app/assets/stylesheets/application.tailwind.css").exist?
-  say "Add default app/assets/stylesheets/application.tailwind.css"
-  copy_file "#{__dir__}/application.tailwind.css", "app/assets/stylesheets/application.tailwind.css"
+unless TAILWIND_ASSET_PATH.join("application.tailwind.css").exist?
+  say "Add default #{TAILWIND_ASSET_PATH}/application.tailwind.css"
+  copy_file "#{__dir__}/application.tailwind.css", TAILWIND_ASSET_PATH.join("application.tailwind.css")
 end
 
 if Rails.root.join("Procfile.dev").exist?

--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -8,7 +8,7 @@ module Tailwindcss
 
         command = [
           Tailwindcss::Ruby.executable(**kwargs),
-          "-i", rails_root.join("app/assets/stylesheets/application.tailwind.css").to_s,
+          "-i", rails_root.join("app/assets/tailwind/application.tailwind.css").to_s,
           "-o", rails_root.join("app/assets/builds/tailwind.css").to_s,
         ]
 

--- a/lib/tailwindcss/engine.rb
+++ b/lib/tailwindcss/engine.rb
@@ -6,6 +6,12 @@ module Tailwindcss
       Rails.application.config.generators.stylesheets = false
     end
 
+    initializer "tailwindcss.exclude_asset_path", after: "propshaft.append_assets_path" do
+      if Rails.application.config.assets.excluded_paths # the app may not be using Propshaft
+        Rails.application.config.assets.excluded_paths << Rails.root.join("app/assets/tailwind")
+      end
+    end
+
     config.app_generators do |g|
       g.template_engine :tailwindcss
     end

--- a/test/integration/user_install_test.sh
+++ b/test/integration/user_install_test.sh
@@ -37,7 +37,7 @@ bin/rails tailwindcss:install
 
 # TEST: tailwind was installed correctly
 grep -q "<main class=\"container" app/views/layouts/application.html.erb
-test -a app/assets/stylesheets/application.tailwind.css
+test -a app/assets/tailwind/application.tailwind.css
 
 # TEST: rake tasks don't exec (#188)
 cat <<EOF >> Rakefile
@@ -46,7 +46,7 @@ task :still_here do
 end
 EOF
 
-cat >> app/assets/stylesheets/application.tailwind.css <<EOF
+cat >> app/assets/tailwind/application.tailwind.css <<EOF
 @theme { --color-special: #abc12399; }
 EOF
 

--- a/test/integration/user_upgrade_test.sh
+++ b/test/integration/user_upgrade_test.sh
@@ -75,10 +75,12 @@ if grep -q inter-font app/views/layouts/application.html.erb ; then
 fi
 
 # TEST: moving the postcss file
-if [ ! -f postcss.config.js ] ; then
-  echo "FAIL: postcss.config.js not moved"
-  exit 1
-fi
+test ! -a config/postcss.config.js
+test   -a postcss.config.js
+
+# TEST: moving application.tailwind.css
+test ! -a app/assets/stylesheets/application.tailwind.css
+test   -a app/assets/tailwind/application.tailwind.css
 
 # generate CSS
 bin/rails tailwindcss:build[verbose]


### PR DESCRIPTION
This file should not be included in the stylesheet link tags served to user agents. But by default, Rails 8 apps add a tag for all CSS files under `app/assets` (courtesy of a Propshaft feature handling a source named `:all`), and so this file is being included unintentionally.

Going forward, in version 4.x of this gem (which pins to Tailwind v4), the installer will place the file into `app/assets/tailwind`. The upgrader will move it from `app/assets/stylesheets` to `app/assets/tailwind`.

And the gem's railtie adds `app/assets/tailwind` to `config.assets.excluded_paths` to make sure it doesn't get served up by the `stylesheet_link_tags :app` call in the application layout.

This is being tested with both Rails 7.2 (without Propshaft) and Rails 8 (with Propshaft) and it looks good.

Fixes #470