### PR TITLE
Properly invoke the initializer to have Propshaft ignore tailwind

### DIFF
--- a/lib/tailwindcss/engine.rb
+++ b/lib/tailwindcss/engine.rb
@@ -6,7 +6,7 @@ module Tailwindcss
       Rails.application.config.generators.stylesheets = false
     end
 
-    initializer "tailwindcss.exclude_asset_path", after: "propshaft.append_assets_path" do
+    initializer "tailwindcss.exclude_asset_path", before: "propshaft.append_assets_path" do
       if Rails.application.config.assets.excluded_paths # the app may not be using Propshaft
         Rails.application.config.assets.excluded_paths << Rails.root.join("app/assets/tailwind")
       end


### PR DESCRIPTION
Fixes #477, originally #470 was incompletely fixed.