### PR TITLE
Hide tailwindcss:authentication from rails g

### DIFF
--- a/lib/generators/tailwindcss/authentication/authentication_generator.rb
+++ b/lib/generators/tailwindcss/authentication/authentication_generator.rb
@@ -3,6 +3,8 @@ require "rails/generators/erb/authentication/authentication_generator"
 module Tailwindcss
   module Generators
     class AuthenticationGenerator < Erb::Generators::AuthenticationGenerator
+      hide!
+
       source_root File.expand_path("templates", __dir__)
     end
   end


### PR DESCRIPTION
If you run `rails g` you can see the following output under Tailwindcss:

```
Tailwindcss:
  tailwindcss:authentication
```

You would normally run just `rails g authentication` and it will pick your template engine of choice (tailwindcss comes up as a template engine) and run that generator for you.

This PR hides it from the help text, similar to https://github.com/rails/rails/pull/53798 (does the same to `erb:authentication`).