### PR TITLE
Implement Engines support

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,12 @@ Then you can use yarn or npm to install the dependencies.
 
 If you need to use a custom input or output file, you can run `bundle exec tailwindcss` to access the platform-specific executable, and give it your own build options.
 
+## Rails Engines support
+
+If you have Rails Engines in your application that use Tailwind CSS, they will be automatically included in the Tailwind build as long as they conform to next conventions:
+
+- The engine must have `tailwindcss-rails` as gem dependency.
+- The engine must have a `app/assets/tailwind/<engine_name>/application.css` file or your application must have overridden file in the same location of your application root.
 
 ## Troubleshooting
 

--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -31,6 +31,40 @@ module Tailwindcss
       def rails_css_compressor?
         defined?(Rails) && Rails&.application&.config&.assets&.css_compressor.present?
       end
+
+      def engines_tailwindcss_roots
+        return [] unless defined?(Rails)
+
+        Rails::Engine.subclasses.select do |engine|
+          begin
+            spec = Gem::Specification.find_by_name(engine.engine_name)
+            spec.dependencies.any? { |d| d.name == 'tailwindcss-rails' }
+          rescue Gem::MissingSpecError
+            false
+          end
+        end.map do |engine|
+          [
+            Rails.root.join("app/assets/tailwind/#{engine.engine_name}/application.css"),
+            engine.root.join("app/assets/tailwind/#{engine.engine_name}/application.css")
+          ].select(&:exist?).compact.first.to_s
+        end.compact
+      end
+
+      def enhance_command(command)
+        engine_roots = Tailwindcss::Commands.engines_tailwindcss_roots
+        if engine_roots.any?
+          Tempfile.create('tailwind.css') do |file|
+            file.write(engine_roots.map { |root| "@import \"#{root}\";" }.join("\n"))
+            file.write("\n@import \"#{Rails.root.join('app/assets/tailwind/application.css')}\";\n")
+            file.rewind
+            transformed_command = command.dup
+            transformed_command[2] = file.path
+            yield transformed_command if block_given?
+          end
+        else
+          yield command if block_given?
+        end
+      end
     end
   end
 end

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -3,8 +3,10 @@ namespace :tailwindcss do
   task build: :environment do |_, args|
     debug = args.extras.include?("debug")
     command = Tailwindcss::Commands.compile_command(debug: debug)
-    puts command.inspect if args.extras.include?("verbose")
-    system(*command, exception: true)
+    Tailwindcss::Commands.enhance_command(command) do |transformed_command|
+      puts transformed_command.inspect if args.extras.include?("verbose")
+      system(*transformed_command, exception: true)
+    end
   end
 
   desc "Watch and build your Tailwind CSS on file changes"
@@ -13,8 +15,10 @@ namespace :tailwindcss do
     poll = args.extras.include?("poll")
     always = args.extras.include?("always")
     command = Tailwindcss::Commands.watch_command(always: always, debug: debug, poll: poll)
-    puts command.inspect if args.extras.include?("verbose")
-    system(*command)
+    Tailwindcss::Commands.enhance_command(command) do |transformed_command|
+      puts transformed_command.inspect if args.extras.include?("verbose")
+      system(*transformed_command)
+    end
   rescue Interrupt
     puts "Received interrupt, exiting tailwindcss:watch" if args.extras.include?("verbose")
   end


### PR DESCRIPTION
This PR implements support for Rails Engines Tailwind styles. It does not require configuration, but sets basic conventions and allows users to redefine engine styles in the host application.