### PR TITLE
Remove inter font license from the README as the font is no longer packaged

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,4 +422,3 @@ The inline version also works:
 ## License
 
 Tailwind for Rails is released under the [MIT License](https://opensource.org/licenses/MIT).
-The Inter font is released under the [SIL Open Font License, Version 1.1](https://github.com/rsms/inter/blob/master/LICENSE.txt).


### PR DESCRIPTION
Since the inter font is no longer packaged within this project, I think it doesn't make sense to add its license anymore. 