### PR TITLE
test: update the integration install test to use static variable

### DIFF
--- a/test/integration/user_install_test.sh
+++ b/test/integration/user_install_test.sh
@@ -7,7 +7,8 @@ set -eux
 
 # set up dependencies
 rm -f Gemfile.lock
-bundle remove actionmailer
+bundle remove actionmailer || true
+bundle remove rails || true
 bundle add rails --skip-install ${RAILSOPTS:-}
 bundle install --prefer-local
 
@@ -47,7 +48,7 @@ end
 EOF
 
 cat >> app/assets/tailwind/application.css <<EOF
-@theme { --color-special: #abc12399; }
+@theme static { --color-special: #abc12399; }
 EOF
 
 bin/rails tailwindcss:build still_here | grep "Rake process did not exit early"

--- a/test/integration/user_upgrade_test.sh
+++ b/test/integration/user_upgrade_test.sh
@@ -7,7 +7,8 @@ set -eux
 
 # set up dependencies
 rm -f Gemfile.lock
-bundle remove actionmailer
+bundle remove actionmailer || true
+bundle remove rails || true
 bundle add rails --skip-install ${RAILSOPTS:-}
 bundle install --prefer-local
 


### PR DESCRIPTION
In tailwindcss v4.0.5, tailwindlabs/tailwindcss#16211 is smarter about not including unused theme variables, but `static` is the documented way to opt into the older behavior.

