### PR TITLE
Run puma plugin in debug mode

### DIFF
--- a/lib/puma/plugin/tailwindcss.rb
+++ b/lib/puma/plugin/tailwindcss.rb
@@ -13,7 +13,7 @@ Puma::Plugin.create do
       # If we use system(*command) instead, IRB and Debug can't read from $stdin
       # correctly bacause some keystrokes will be taken by watch_command.
       begin
-        IO.popen(Tailwindcss::Commands.watch_command, 'r+') do |io|
+        IO.popen(Tailwindcss::Commands.watch_command(debug: true), 'r+') do |io|
           IO.copy_stream(io, $stdout)
         end
       rescue Interrupt


### PR DESCRIPTION
As far as I understood, puma plugin is only designed for development, so it makes sense to avoid CSS minification in this env.


https://github.com/rails/tailwindcss-rails/blob/08486ae14237e7381f3f874e606df1ba432947dc/lib/tailwindcss/commands.rb#L16