### PR TITLE
ci: use the latest @tailwindcss/upgrade package

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ $ bin/rails tailwindcss:upgrade
       remove    app/assets/stylesheets/application.tailwind.css
 10.9.0
   Running the upstream Tailwind CSS upgrader
-         run    npx @tailwindcss/upgrade@next --force --config /home/user/myapp/config/tailwind.config.js from "."
+         run    npx @tailwindcss/upgrade --force --config /home/user/myapp/config/tailwind.config.js from "."
 ≈ tailwindcss v4.0.0
 │ Searching for CSS files in the current directory and its subdirectories…
 │ ↳ Linked `./config/tailwind.config.js` to `./app/assets/tailwind/application.css`

--- a/lib/install/upgrade_tailwindcss.rb
+++ b/lib/install/upgrade_tailwindcss.rb
@@ -46,7 +46,7 @@ end
 
 if system("npx --version")
   say "Running the upstream Tailwind CSS upgrader"
-  command = Shellwords.join(["npx", "@tailwindcss/upgrade@next", "--force", "--config", TAILWIND_CONFIG_PATH.to_s])
+  command = Shellwords.join(["npx", "@tailwindcss/upgrade", "--force", "--config", TAILWIND_CONFIG_PATH.to_s])
   success = run(command, abort_on_failure: false)
   unless success
     say "The upgrade tool failed!", :red


### PR DESCRIPTION
The upgrade tests started failing in CI with this error from the tailwind upgrade tool:

    │ Migrating templates…

    TypeError: Cannot read properties of undefined (reading 'flatMap')
        at ca (file:///home/runner/.npm/_npx/0044b4041b3b52e1/node_modules/@tailwindcss/upgrade/dist/index.mjs:229:5661)
      The upgrade tool failed!
              You probably need to update your configuration. Please read the error messages,
              and check the Tailwind CSS upgrade guide at https://tailwindcss.com/docs/upgrade-guide.

and it seems like updating to the latest version of the upgrade tool fixes it.