### PR TITLE
suppress caniuse-lite is outdated warning

### DIFF
--- a/lib/puma/plugin/tailwindcss.rb
+++ b/lib/puma/plugin/tailwindcss.rb
@@ -13,7 +13,7 @@ Puma::Plugin.create do
       # If we use system(*command) instead, IRB and Debug can't read from $stdin
       # correctly bacause some keystrokes will be taken by watch_command.
       begin
-        IO.popen(Tailwindcss::Commands.watch_command, 'r+') do |io|
+        IO.popen({'BROWSERSLIST_IGNORE_OLD_DATA' => '1'}, Tailwindcss::Commands.watch_command, 'r+') do |io|
           IO.copy_stream(io, $stdout)
         end
       rescue Interrupt


### PR DESCRIPTION
Adds BROWSERSLIST_IGNORE_OLD_DATA to the environment when spawning from the Puma helper.  This avoids a 3 line warning message about stale browser data on every process startup.

I added this on the v3 branch only because that branch is expected to change rarely.  v4 sees frequent updates so likely no need for this configuration (at least until v5).

Fixes flavorjones/tailwindcss-ruby#76