### PR TITLE
Pin the npm upgrade task to @tailwindcss/upgrade@4.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Then, run `bin/rails tailwindcss:upgrade`. Among other things, this will try to 
 - If present, moves `app/assets/stylesheets/application.tailwind.css` to `app/assets/tailwind/application.css`.
 - Removes unnecessary `stylesheet_link_tag "tailwindcss"` tags from the application layout.
 - Removes references to the Inter font from the application layout.
-- Runs the upstream upgrader (note: requires `npx` to run the one-time upgrade, but highly recommended).
+- Runs v4.1.4 of the upstream upgrader (note: requires `npx` to run the one-time upgrade, but highly recommended).
 
 </details>
 
@@ -145,7 +145,7 @@ $ bin/rails tailwindcss:upgrade
       remove    app/assets/stylesheets/application.tailwind.css
 10.9.0
   Running the upstream Tailwind CSS upgrader
-         run    npx @tailwindcss/upgrade --force --config /home/user/myapp/config/tailwind.config.js from "."
+         run    npx @tailwindcss/upgrade@4.1.4 --force --config /home/user/myapp/config/tailwind.config.js from "."
 ≈ tailwindcss v4.0.0
 │ Searching for CSS files in the current directory and its subdirectories…
 │ ↳ Linked `./config/tailwind.config.js` to `./app/assets/tailwind/application.css`

--- a/lib/install/upgrade_tailwindcss.rb
+++ b/lib/install/upgrade_tailwindcss.rb
@@ -45,8 +45,14 @@ if OLD_TAILWIND_ASSET_PATH.exist?
 end
 
 if system("npx --version")
+  # We're pinning to v4.1.4 because v4.1.5 of the upgrade tool introduces a dependency version check
+  # on tailwind and I haven't been able to figure out how to get that to work reliably and I am
+  # extremely frustrated with the whole thing. See #544
+  #
+  # At some point we will probably need to unpin this at which point I am sincerely hoping that
+  # someone else will do it.
   say "Running the upstream Tailwind CSS upgrader"
-  command = Shellwords.join(["npx", "@tailwindcss/upgrade", "--force", "--config", TAILWIND_CONFIG_PATH.to_s])
+  command = Shellwords.join(["npx", "@tailwindcss/upgrade@4.1.4", "--force", "--config", TAILWIND_CONFIG_PATH.to_s])
   success = run(command, abort_on_failure: false)
   unless success
     say "The upgrade tool failed!", :red


### PR DESCRIPTION
We're pinning to v4.1.4 because v4.1.5 of the upgrade tool [introduces a dependency version check on tailwind](https://github.com/tailwindlabs/tailwindcss/pull/17717) and I haven't been able to figure out how to get that to work reliably and I am extremely frustrated with the whole thing.

The error we're seeing in CI and in development with v4.1.5:

```
run    npx @tailwindcss/upgrade --force --config /home/flavorjones/code/oss/tailwindcss-rails/My\ Workspace/test-upgrade/config/tailwind.config.js from "."
≈ tailwindcss v4.1.5

│ Searching for CSS files in the current directory and its subdirectories…

Error: Tailwind CSS is not installed
    at k.factory (file:///home/flavorjones/.local/share/mise/installs/node/22.12.0/lib/node_modules/@tailwindcss/upgrade/dist/index.mjs:194:727)
    at k.get (file:///home/flavorjones/.local/share/mise/installs/node/22.12.0/lib/node_modules/@tailwindcss/upgrade/dist/index.mjs:4:6572)
    at da (file:///home/flavorjones/.local/share/mise/installs/node/22.12.0/lib/node_modules/@tailwindcss/upgrade/dist/index.mjs:194:820)
    at E (file:///home/flavorjones/.local/share/mise/installs/node/22.12.0/lib/node_modules/@tailwindcss/upgrade/dist/index.mjs:194:641)
    at xl (file:///home/flavorjones/.local/share/mise/installs/node/22.12.0/lib/node_modules/@tailwindcss/upgrade/dist/index.mjs:241:10846)
```

At some point we will probably need to unpin this at which point I am sincerely hoping that someone else will figure out how to do it.
