### PR TITLE
check for system test existence before modifying

### DIFF
--- a/lib/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/lib/generators/test_unit/scaffold/scaffold_generator.rb
@@ -4,8 +4,9 @@ module TestUnit # :nodoc:
   module Generators # :nodoc:
     class ScaffoldGenerator < Base # :nodoc:
       def fix_system_test
-        if turbo_defined?
-          gsub_file File.join("test/system", class_path, "#{file_name.pluralize}_test.rb"),
+        system_test_file = File.join("test/system", class_path, "#{file_name.pluralize}_test.rb")
+        if turbo_defined? && File.exist?(system_test_file)
+          gsub_file system_test_file,
                     /(click_on.*Destroy this.*)$/,
                     "accept_confirm { \\1 }"
         end


### PR DESCRIPTION
fixes https://github.com/rails/tailwindcss-rails/issues/559

With this change the scaffold generator no longer assumes the existence of a system test file. Rails projects can be initialized without system tests using the --skip-system-test option.