### PR TITLE
check Rails configuration before modifying system test

### DIFF
--- a/lib/generators/test_unit/scaffold/scaffold_generator.rb
+++ b/lib/generators/test_unit/scaffold/scaffold_generator.rb
@@ -4,7 +4,7 @@ module TestUnit # :nodoc:
   module Generators # :nodoc:
     class ScaffoldGenerator < Base # :nodoc:
       def fix_system_test
-        if turbo_defined?
+        if system_tests_enabled? && turbo_defined?
           gsub_file File.join("test/system", class_path, "#{file_name.pluralize}_test.rb"),
                     /(click_on.*Destroy this.*)$/,
                     "accept_confirm { \\1 }"
@@ -15,6 +15,10 @@ module TestUnit # :nodoc:
 
       def turbo_defined?
         defined?(Turbo)
+      end
+
+      def system_tests_enabled?
+        defined?(Rails.configuration.generators) && Rails.configuration.generators.system_tests
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/rails/tailwindcss-rails/issues/559

With this change the scaffold generator no longer assumes the Rails project has system tests enabled.

This is a better approach than my initial PR #560. This approach uses Rails configuration to determine whether to modify a system test.