### PR TITLE
Filter engine stubs from Propshaft :app stylesheet resolution

### DIFF
--- a/lib/tailwindcss/engine.rb
+++ b/lib/tailwindcss/engine.rb
@@ -12,6 +12,32 @@ module Tailwindcss
       end
     end
 
+    # Filter engine CSS stubs from Propshaft's :app stylesheet resolution.
+    #
+    # The tailwindcss:engines task generates intermediate stub files at
+    # app/assets/builds/tailwind/<engine>.css containing @import directives
+    # with absolute filesystem paths. These are consumed by the Tailwind CLI
+    # at build time and inlined into the compiled tailwind.css output.
+    #
+    # When hosts use stylesheet_link_tag :app (the Rails 8.1 default),
+    # Propshaft globs app/assets/**/*.css and serves these stubs directly
+    # to the browser. The browser interprets the absolute path as a URL
+    # and gets a 404.
+    #
+    # Propshaft's excluded_paths can't help here — it only filters top-level
+    # load path directories, not subdirectories within a load path.
+    initializer "tailwindcss.filter_engine_stubs" do
+      ActiveSupport.on_load(:action_view) do
+        if defined?(Propshaft::Helper)
+          Propshaft::Helper.prepend(Module.new {
+            def app_stylesheets_paths
+              super.reject { |path| path.start_with?("tailwind/") }
+            end
+          })
+        end
+      end
+    end
+
     config.app_generators do |g|
       g.template_engine :tailwindcss
     end

--- a/test/lib/tailwindcss/engine_test.rb
+++ b/test/lib/tailwindcss/engine_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class Tailwindcss::EngineTest < ActiveSupport::TestCase
+  # Simulates Propshaft::Helper#app_stylesheets_paths returning both
+  # compiled output and engine stubs, then verifies the filter rejects stubs.
+  test "filter_engine_stubs rejects paths starting with tailwind/" do
+    helper_mod = Module.new do
+      def app_stylesheets_paths
+        ["application.css", "tailwind.css", "tailwind/my_engine.css", "tailwind/other_engine.css"]
+      end
+    end
+
+    filter_mod = Module.new do
+      def app_stylesheets_paths
+        super.reject { |path| path.start_with?("tailwind/") }
+      end
+    end
+
+    obj = Object.new
+    obj.extend(helper_mod)
+    obj.singleton_class.prepend(filter_mod)
+
+    result = obj.app_stylesheets_paths
+    assert_includes result, "tailwind.css", "Compiled output should pass through"
+    assert_includes result, "application.css", "Non-tailwind assets should pass through"
+    refute_includes result, "tailwind/my_engine.css", "Engine stubs should be filtered"
+    refute_includes result, "tailwind/other_engine.css", "Engine stubs should be filtered"
+  end
+
+  test "filter_engine_stubs passes through when no engine stubs exist" do
+    helper_mod = Module.new do
+      def app_stylesheets_paths
+        ["application.css", "tailwind.css"]
+      end
+    end
+
+    filter_mod = Module.new do
+      def app_stylesheets_paths
+        super.reject { |path| path.start_with?("tailwind/") }
+      end
+    end
+
+    obj = Object.new
+    obj.extend(helper_mod)
+    obj.singleton_class.prepend(filter_mod)
+
+    assert_equal ["application.css", "tailwind.css"], obj.app_stylesheets_paths
+  end
+end


### PR DESCRIPTION
I've been building a Rails engine that ships Tailwind CSS using the `tailwindcss:engines` mechanism from #554, and I ran into an issue with `stylesheet_link_tag :app`.

## What's happening

When the host app uses `stylesheet_link_tag :app` (the default in Rails 8.1 layouts), Propshaft globs `app/assets/**/*.css` and generates a `<link>` tag for each match. This picks up the engine stub files at `app/assets/builds/tailwind/<engine>.css` in addition to the compiled `tailwind.css`.

The browser receives the stub, which contains an `@import` with an absolute filesystem path:

```css
@import "/Users/me/.../my_engine/app/assets/tailwind/my_engine/engine.css";
```

The browser interprets that as a URL and gets a 404. The compiled `tailwind.css` already has everything inlined, so nothing is actually broken, but you get console errors on every page load.

**Reproduction**: https://github.com/steveclarke/tailwindcss-rails-engine-stub-repro

Clone it, `bundle install`, `bin/rails tailwindcss:build`, `bin/rails server`, open the console.

## Verified with the repro app

**Stock `tailwindcss-rails` 4.4.0** — three stylesheet links, stub served to browser:

```html
<link rel="stylesheet" href="/assets/application-8b441ae0.css" />
<link rel="stylesheet" href="/assets/tailwind-8272e5b1.css" />
<link rel="stylesheet" href="/assets/tailwind/mini_engine-8dad903a.css" />  <!-- the stub -->
```

**With this fix** — stub is filtered, only two links:

```html
<link rel="stylesheet" href="/assets/application-8b441ae0.css" />
<link rel="stylesheet" href="/assets/tailwind-8272e5b1.css" />
```

## Why excluded_paths doesn't work here

I initially tried adding `app/assets/builds/tailwind` to `excluded_paths`, similar to how `app/assets/tailwind` is already excluded. But `excluded_paths` only filters top-level entries from the load path array — it does exact string matching against directories like `app/assets/builds`. Since `app/assets/builds/tailwind` is a subdirectory within that load path, it doesn't match and nothing gets excluded.

## The fix

This PR adds a filter on `Propshaft::Helper#app_stylesheets_paths` that rejects assets whose logical paths start with `tailwind/`. These are always engine stubs (generated by `tailwindcss:engines` into `app/assets/builds/tailwind/`). The compiled output has the logical path `tailwind.css` (no slash), so it passes through fine.

The filter is guarded with `defined?(Propshaft::Helper)` so it's a no-op if the app uses Sprockets.

This is the same general approach as the existing `excluded_paths` initializer — just at a different layer, since Propshaft doesn't support subdirectory exclusions.

Not sure if there's a cleaner way to handle this, but this is the best I could figure out after reading through the Propshaft source. Happy to adjust if there's a better approach.

Related: #477 fixed the same class of issue for `app/assets/tailwind/` (the source directory). This covers the stubs directory that was introduced later by #554.