### PR TITLE
Ignore Rails runtime dirs in Tailwind source scanning

### DIFF
--- a/lib/install/application.css
+++ b/lib/install/application.css
@@ -1,1 +1,5 @@
 @import "tailwindcss";
+
+@source not "../../../log";
+@source not "../../../tmp";
+@source not "../../../storage";

--- a/test/integration/user_install_test.sh
+++ b/test/integration/user_install_test.sh
@@ -41,6 +41,9 @@ function install_tailwindcss {
   # TEST: tailwind was installed correctly
   grep -q "<main class=\"container" app/views/layouts/application.html.erb
   test -a app/assets/tailwind/application.css
+  grep -q '@source not "../../../log";' app/assets/tailwind/application.css
+  grep -q '@source not "../../../tmp";' app/assets/tailwind/application.css
+  grep -q '@source not "../../../storage";' app/assets/tailwind/application.css
 }
 
 # Application variation #1 ----------------------------------------


### PR DESCRIPTION
This excludes Rails runtime directories from the default Tailwind source scan.

Tailwind watches generated files under directories like `log`, `tmp`, and `storage` by default, which can trigger unnecessary rebuilds in development. The default generated `application.css` now opts those directories out with `@source not`.

Fixes #491.

Tests:
- `bundle exec bin/test`
