### PR TITLE
Harden github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,18 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      semver-major-days: 7
+      semver-minor-days: 3
+      semver-patch-days: 2
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,42 @@ on:
     branches:
       - '*'
 
+permissions: {}
+
 jobs:
+  lint-actions:
+    name: GitHub Actions audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          advanced-security: false
+
   tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         ruby: ["3.1", "3.2", "3.3", "3.4", "4.0", "head"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
       - run: rm Gemfile.lock
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0 # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation
         with:
           ruby-version: ${{matrix.ruby}}
           bundler: latest
@@ -38,11 +63,15 @@ jobs:
       matrix:
         plat: [ "ubuntu", "macos" ]
     runs-on: ${{matrix.plat}}-latest
+    permissions:
+      contents: read
     env:
       GEM_HOME: ${{ github.workspace }}/.gem # Needs to be a writable directory to bundle remove/add
     steps:
-      - uses: actions/checkout@v5
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: "4.0"
           bundler: latest
@@ -55,11 +84,15 @@ jobs:
       matrix:
         plat: [ "ubuntu", "macos" ]
     runs-on: ${{matrix.plat}}-latest
+    permissions:
+      contents: read
     env:
       GEM_HOME: ${{ github.workspace }}/.gem # Needs to be a writable directory to bundle remove/add
     steps:
-      - uses: actions/checkout@v5
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: "4.0"
           bundler: latest

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -13,17 +13,23 @@ on:
 env:
   GEM_HOME: ${{ github.workspace }}/.gem # Needs to be a writable directory to bundle remove/add
 
+permissions: {}
+
 jobs:
   tests:
     name: "tests (rails main)"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         ruby: ["4.0"]
     steps:
-      - uses: actions/checkout@v5
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: ${{matrix.ruby}}
       - run: |
@@ -38,6 +44,8 @@ jobs:
   user-install:
     name: "user-install (rails ${{ matrix.ref }})"
     runs-on: ${{matrix.plat}}-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -46,8 +54,10 @@ jobs:
     env:
       RAILSOPTS: --git=https://github.com/rails/rails --ref=${{ matrix.ref }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: "4.0"
           bundler: latest
@@ -57,6 +67,8 @@ jobs:
   user-upgrade:
     name: "user-upgrade (rails ${{ matrix.ref }})"
     runs-on: ${{matrix.plat}}-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -65,8 +77,10 @@ jobs:
     env:
       RAILSOPTS: --git=https://github.com/rails/rails --ref=${{ matrix.ref }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: "4.0"
           bundler: latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,14 @@ This doc is a brief introduction on modifying and maintaining this gem.
 
 ### Running the test suite
 
-The unit tests are run with `bundle exec rake test`
+Run `bin/setup` once to install bundler dependencies and the linting tools.
 
-There is an additional integration test which runs in CI, `test/integration/user_install_test.sh` which you may also want to run.
+Run `bin/ci` for a complete set of tests which includes:
+
+- unit tests (run with `bin/test` or `bundle exec rake test`)
+- integration tests in `test/integration/`
+
+And, if the proper tools (actionlint and zizmor) are installed, Github Actions will be linted.
 
 
 ### Testing in a Rails app

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "active_support/continuous_integration"
+
+def installed?(command)
+  system("command -v #{command} > /dev/null 2>&1")
+end
+
+ActiveSupport::ContinuousIntegration.run do
+  if installed?("actionlint")
+    step "Lint: GitHub Actions", "actionlint"
+  else
+    heading "Skipping Lint: GitHub Actions", "actionlint not installed", type: :subtitle
+  end
+
+  if installed?("zizmor")
+    step "Security: zizmor", "zizmor", "."
+  else
+    heading "Skipping Security: zizmor", "zizmor not installed", type: :subtitle
+  end
+
+  step "Tests: unit", "bin/test"
+  step "Tests: integration (user install)", "test/integration/user_install_test.sh"
+  step "Tests: integration (user upgrade)", "test/integration/user_upgrade_test.sh"
+end

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+bundle install
+
+for tool in actionlint shellcheck zizmor; do
+  if ! command -v "$tool" &> /dev/null; then
+    if command -v brew &> /dev/null; then
+      brew install "$tool"
+    elif command -v pacman &> /dev/null; then
+      sudo pacman -S --noconfirm "$tool"
+    else
+      echo "Note: $tool not installed; bin/ci will skip its check" >&2
+    fi
+  fi
+done


### PR DESCRIPTION
- address zizmor and actionlint warnings in workflow files
- add CI job to lint workflow files
- add `bin/setup` and `bin/ci` to lint actions in development
