### PR TITLE
Support new `--silent` tailwind flag via `[silent]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `tailwindcss-rails` Changelog
 
+## next / unreleased
+
+### Improved
+
+* New `silent` flag on `tailwindcss:build` and `tailwindcss:watch` tasks to suppress non-error output from the tailwindcss CLI (e.g., `bin/rails tailwindcss:watch[silent]`). Requires the tailwindcss CLI's `--silent` option, which was added in https://github.com/tailwindlabs/tailwindcss/pull/20100 (post-v4.3.0).
+
+
 ## v4.4.0 / 2025-10-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -266,10 +266,12 @@ Synopsis:
 - `bin/rails tailwindcss:install` - installs the configuration file, output file, and `Procfile.dev`
 - `bin/rails tailwindcss:build` - generate the output file
   - `bin/rails tailwindcss:build[debug]` - generate unminimized output
+  - `bin/rails tailwindcss:build[silent]` - suppress non-error output from tailwindcss (requires tailwindcss CLI support for `--silent`)
   - `bin/rails tailwindcss:build[verbose]` - emit the commands being run
 - `bin/rails tailwindcss:watch` - start live rebuilds, generating output on file changes
   - `bin/rails tailwindcss:watch[debug]` - generate unminimized output
   - `bin/rails tailwindcss:watch[always]` - for systems without TTY (e.g., some docker containers)
+  - `bin/rails tailwindcss:watch[silent]` - suppress non-error output from tailwindcss (requires tailwindcss CLI support for `--silent`)
   - `bin/rails tailwindcss:watch[verbose]` - emit the commands being run
 
 Note that you can combine task options, e.g. `rails tailwindcss:watch[debug,always]`.

--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -14,9 +14,7 @@ module Tailwindcss
         ]
 
         command << "--minify" unless (debug || rails_css_compressor?)
-        if silent
-          command << "--silent"
-        end
+        command << "--silent" if silent
 
         postcss_path = rails_root.join("postcss.config.js")
         command += ["--postcss", postcss_path.to_s] if File.exist?(postcss_path)

--- a/lib/tailwindcss/commands.rb
+++ b/lib/tailwindcss/commands.rb
@@ -3,7 +3,7 @@ require "tailwindcss/ruby"
 module Tailwindcss
   module Commands
     class << self
-      def compile_command(debug: false, **kwargs)
+      def compile_command(debug: false, silent: false, **kwargs)
         debug = ENV["TAILWINDCSS_DEBUG"].present? if ENV.key?("TAILWINDCSS_DEBUG")
         rails_root = defined?(Rails) ? Rails.root : Pathname.new(Dir.pwd)
 
@@ -14,6 +14,9 @@ module Tailwindcss
         ]
 
         command << "--minify" unless (debug || rails_css_compressor?)
+        if silent
+          command << "--silent"
+        end
 
         postcss_path = rails_root.join("postcss.config.js")
         command += ["--postcss", postcss_path.to_s] if File.exist?(postcss_path)

--- a/lib/tasks/build.rake
+++ b/lib/tasks/build.rake
@@ -2,9 +2,10 @@ namespace :tailwindcss do
   desc "Build your Tailwind CSS"
   task build: [:environment, :engines] do |_, args|
     debug = args.extras.include?("debug")
+    silent = args.extras.include?("silent")
     verbose = args.extras.include?("verbose")
 
-    command = Tailwindcss::Commands.compile_command(debug: debug)
+    command = Tailwindcss::Commands.compile_command(debug: debug, silent: silent)
     env = Tailwindcss::Commands.command_env(verbose: verbose)
     puts "Running: #{Shellwords.join(command)}" if verbose
 
@@ -15,9 +16,10 @@ namespace :tailwindcss do
   task watch: [:environment, :engines] do |_, args|
     debug = args.extras.include?("debug")
     always = args.extras.include?("always")
+    silent = args.extras.include?("silent")
     verbose = args.extras.include?("verbose")
 
-    command = Tailwindcss::Commands.watch_command(always: always, debug: debug)
+    command = Tailwindcss::Commands.watch_command(always: always, debug: debug, silent: silent)
     env = Tailwindcss::Commands.command_env(verbose: verbose)
     puts "Running: #{Shellwords.join(command)}" if verbose
 

--- a/test/lib/tailwindcss/commands_test.rb
+++ b/test/lib/tailwindcss/commands_test.rb
@@ -59,6 +59,16 @@ class Tailwindcss::CommandsTest < ActiveSupport::TestCase
     end
   end
 
+  test ".compile_command silent flag" do
+    Rails.stub(:root, File) do # Rails.root won't work in this test suite
+      actual = Tailwindcss::Commands.compile_command
+      refute_includes(actual, "--silent")
+
+      actual = Tailwindcss::Commands.compile_command(silent: true)
+      assert_includes(actual, "--silent")
+    end
+  end
+
   test ".compile_command when Rails compression is on" do
     Rails.stub(:root, File) do # Rails.root won't work in this test suite
       Tailwindcss::Commands.stub(:rails_css_compressor?, true) do
@@ -116,6 +126,12 @@ class Tailwindcss::CommandsTest < ActiveSupport::TestCase
       assert_equal(executable, actual.first)
       assert_includes(actual, "-w")
       assert_includes(actual, "always")
+
+      actual = Tailwindcss::Commands.watch_command(silent: true)
+      assert_kind_of(Array, actual)
+      assert_equal(executable, actual.first)
+      assert_includes(actual, "-w")
+      assert_includes(actual, "--silent")
     end
   end
 end


### PR DESCRIPTION
The next version of tailwind (after 4.3.0) will support a `--silent` flag: https://github.com/tailwindlabs/tailwindcss/pull/20100

This PR allows using it like `css: bin/rails tailwindcss:watch[silent]` in a `Procfile.dev`.

If the tailwind version doesn't support the flag it will be silently ignored.