### PR TITLE
ci: update ignore comment to work with dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           persist-credentials: false
       - run: rm Gemfile.lock
-      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0 # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation # v1.306.0
         with:
           ruby-version: ${{matrix.ruby}}
           bundler: latest


### PR DESCRIPTION
Dependabot won't update the version comment if it's followed by the zizmor comment.

See https://github.com/rails/tailwindcss-rails/pull/617 for context