### PR TITLE
Scope Tailwind source scanning to app/ (and lib/) in the install template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # `tailwindcss-rails` Changelog
 
+## next / unreleased
+
+### Fixed
+
+* The install template now scopes Tailwind source scanning to `app/` (plus `lib/`), so `--watch` no longer rebuilds on writes to `log/`, `tmp/`, `storage/`, etc. New installs only. Fixes #491. #628 @ajaynomics
+
+
 ## v4.6.0 / 2026-06-17
 
 ### Fixed

--- a/lib/install/application.css
+++ b/lib/install/application.css
@@ -1,1 +1,10 @@
-@import "tailwindcss";
+/*
+ * `source("../../")` roots Tailwind's source detection at `app/` instead of
+ * the Rails working directory, so `--watch` (e.g. `bin/dev`) stops waking on
+ * writes to `log/`, `tmp/`, `storage/`, and other non-source dirs. See #491.
+ *
+ * Rooting at `app/` would otherwise drop `lib/` from scanning, so `@source`
+ * re-adds it for apps that keep view helpers/components/partials there.
+ */
+@import "tailwindcss" source("../../");
+@source "../../../lib";

--- a/test/integration/user_install_test.sh
+++ b/test/integration/user_install_test.sh
@@ -46,6 +46,11 @@ function install_tailwindcss {
   # TEST: tailwind was installed correctly
   grep -q "<main class=\"container" app/views/layouts/application.html.erb
   test -a app/assets/tailwind/application.css
+
+  # TEST: source scanning is scoped to app/ so the watcher ignores log/, tmp/, etc. (#491)
+  grep -q 'source("../../")' app/assets/tailwind/application.css
+  # TEST: lib/ is still scanned, so classes in helpers/components there aren't dropped (#491)
+  grep -q '@source "../../../lib"' app/assets/tailwind/application.css
 }
 
 # Application variation #1 ----------------------------------------


### PR DESCRIPTION
## What

Changes the installed `app/assets/tailwind/application.css` template from a bare `@import "tailwindcss";` to:

```css
@import "tailwindcss" source("../../");
@source "../../../lib";
```

This is the approach discussed in #491 — `source("../../")` roots Tailwind's [source detection](https://tailwindcss.com/docs/detecting-classes-in-source-files#setting-your-base-path) at `app/` instead of the Rails working directory, so in `--watch` mode (`bin/dev`) the watcher stops waking on writes to `log/`, `tmp/`, `storage/`, and other non-source directories. Today every write to those dirs triggers a needless rebuild ("Done in Xms") even though the compiled CSS never changes.

## The `lib/` tradeoff (per review)

Setting the base path to `app/` would otherwise drop `lib/` from automatic scanning, which could **silently** remove utilities used by view helpers / components some apps keep under `lib/`. That was the concern raised in-thread, and the workaround others landed on was `@source "../../../lib";`. This PR includes that line so no classes are silently dropped, and adds an inline comment in the template explaining the intent and the tradeoff.

## Scope

Install template only — existing apps are unaffected when they upgrade the gem; they'd opt in by editing their own stylesheet.

## Open question — do we want this now, or wait on upstream?

The #491 discussion did not close on "ship it." The watcher behavior was also being tracked upstream in tailwindlabs/tailwindcss#15750, and the last substantive sentiment leaned toward possibly waiting for an upstream fix rather than changing the installed config. There was also a note that @jclusso offered to prepare this. I'm opening this so the diff is concrete, but I don't want to step on that or merge over an unresolved "should we wait?" — happy to close/hand off or hold if the preference is to wait on upstream. Let's confirm the direction in the issue first.

## Tests

The user-install integration test now asserts both directives are present in the installed stylesheet:

```sh
grep -q 'source("../../")' app/assets/tailwind/application.css
grep -q '@source "../../../lib"' app/assets/tailwind/application.css
```

Fixes #491